### PR TITLE
profiles/hydra/master: update minion hostnames

### DIFF
--- a/profiles/hydra/master/default.nix
+++ b/profiles/hydra/master/default.nix
@@ -21,7 +21,7 @@ in
       system = "x86_64-linux";
     }
     {
-      hostName = "hydra-aarch64-linux.holo.host";
+      hostName = "hydra-minion-1.holo.host";
       maxJobs = 96;
       sshKey = "/var/lib/hydra/queue-runner/.ssh/id_ed25519";
       sshUser = "root";

--- a/profiles/hydra/master/default.nix
+++ b/profiles/hydra/master/default.nix
@@ -34,7 +34,7 @@ in
       system = "aarch64-linux";
     }
     {
-      hostName = "208.52.170.228";
+      hostName = "hydra-minion-2.holo.host";
       maxJobs = 12;
       sshKey = "/var/lib/hydra/queue-runner/.ssh/id_ed25519";
       sshUser = "administrator";


### PR DESCRIPTION
Resolves #105. Once merged, temporary `hydra-aarch64-linux.holo.host` `CNAME` record can be removed.