### PR TITLE
profiles/hydra/private-master: private = 1

### DIFF
--- a/profiles/hydra/private-master/default.nix
+++ b/profiles/hydra/private-master/default.nix
@@ -17,7 +17,12 @@
 
   nix.useSandbox = false;
 
-  services.hydra.hydraURL = "https://private-hydra.holo.host";
+  services.hydra = {
+    hydraURL = "https://private-hydra.holo.host";
+    extraConfig = ''
+      private = 1
+    '';
+  };
 
   services.nginx.virtualHosts.hydra = {
     basicAuthFile = "/etc/nixos/htpasswd";


### PR DESCRIPTION
Use work done in https://github.com/NixOS/hydra/commit/bd7b6fc4011825c2e54fb2e7691fd87dc5f91969#diff-b53e04f6219c4eda4a86bdedcc118e85 instead of basic authorization for private Hydra instance.