### PR TITLE
Revert "happ-store, holo-hosting-app: bump to 0.3.0-alpha1"

### DIFF
--- a/overlays/holo-nixpkgs/dna-packages/happ-store/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/happ-store/default.nix
@@ -2,9 +2,9 @@
 
 let
   src = fetchurl {
-    url = "https://github.com/Holo-Host/happ-store/releases/download/0.3.0-alpha1/Qmdu8qqv1sgGyZuZibAaZMGjyL5VvDWCYTzK8dHi2Xo1LW.hApp-store.dna.json";
+    url = "https://github.com/Holo-Host/happ-store/releases/download/0.2.3-alpha1/hApp-store.dna.json";
     name = "happ-store.dna.json";
-    sha256 = "0fadd1dvghjv4v1c750qp61pc0knsy4y892fs0kv5zzpjs22zs2g";
+    sha256 = "0gl0md1qzsii1f0595mw61qv7pmlqiq1zn0y7893cmj2mjc084p9";
   };
 in
 

--- a/overlays/holo-nixpkgs/dna-packages/holo-hosting-app/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/holo-hosting-app/default.nix
@@ -2,9 +2,9 @@
 
 let
   src = fetchurl {
-    url = "https://github.com/Holo-Host/holo-hosting-app/releases/download/0.3.0-alpha1/Qma4tEZUjYHtY4fQqvx3ofBRNfUQ8uPViijfALL4zyupKm.holo-hosting-app.dna.json";
+    url = "https://github.com/Holo-Host/holo-hosting-app/releases/download/0.2.5-alpha1/QmbTLCyz5qEELA16vHuiWGvZK269GSeRxbWttKbz24EmyV.Holo-Hosting-App.dna.json";
     name = "holo-hosting-app.dna.json";
-    sha256 = "1k86wk6ndh78xa22syjaa2ka6wc4d58rjqgzqwqi03vwqfbbyzvy";
+    sha256 = "0xnmzxvcfbl50d0r4a838l4dlcwdmr2rg1s0a73prb3knkylh3si";
   };
 in
 


### PR DESCRIPTION
Reverts Holo-Host/holo-nixpkgs#147

CI doesn't pass: https://hydra.holo.host/eval/237159

Also see: https://github.com/Holo-Host/holo-nixpkgs/pull/147#pullrequestreview-306139640

cc @samrose @zo-el