### PR TITLE
Revert "holoportos-led-daemon: use green as idle color for internal testing"

### DIFF
--- a/overlays/overlay/holoportos-led-daemon/src/main.rs
+++ b/overlays/overlay/holoportos-led-daemon/src/main.rs
@@ -80,7 +80,7 @@ fn main() {
         }
 
         if !is_aurora {
-            aurora_led(&["--device", &device, "--mode", "static", "--color", "green"]);
+            aurora_led(&["--device", &device, "--mode", "aurora"]);
             is_aurora = true;
         }
     }


### PR DESCRIPTION
This reverts commit cc104ed5d904086cf7f28f9dfb596065653f1612.

Rationale is that this was intended to verify that upgrade to new HoloPortOS from https://github.com/Holo-Host/holoportos-legacy was successful. Since we ensured that, we should revert idle LED back to its default state.