### PR TITLE
Start hosting https://hpstatus.holo.host

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -28,8 +28,8 @@ let
   hpstatus = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hpstatus";
-    rev = "a7fae5926f2c8b6bb26111863873dc3ca55b2b6c";
-    sha256 = "1lcvnb93ayb593xgyd8ylwaldmh1s2vp28g7ydgmh598y81ljp57";
+    rev = "005435217305f76f3d51722f462f310a2baeab11";
+    sha256 = "1gszq98xdvq515g2kaxan886p4cgmwgqmb0g7b9a66m5087p3jg4";
   };
 
   holo-envoy = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -25,6 +25,13 @@ let
     sha256 = "1lcvnb93ayb593xgyd8ylwaldmh1s2vp28g7ydgmh598y81ljp57";
   };
 
+  hpstatus = fetchFromGitHub {
+    owner = "Holo-Host";
+    repo = "hpstatus";
+    rev = "a7fae5926f2c8b6bb26111863873dc3ca55b2b6c";
+    sha256 = "1lcvnb93ayb593xgyd8ylwaldmh1s2vp28g7ydgmh598y81ljp57";
+  };
+
   holo-envoy = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "envoy";
@@ -62,6 +69,9 @@ in
     holo-config-derive
     holo-config-generate-cli
     holo-config-generate-web;
+
+  inherit (callPackage hpstatus {}) 
+    hp-status-host-web;
 
   inherit (callPackage npm-to-nix {}) npmToNix;
   inherit (callPackage "${nixpkgs-mozilla}/package-set.nix" {}) rustChannelOf;

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -70,9 +70,7 @@ in
     holo-config-generate-cli
     holo-config-generate-web;
 
-  inherit (callPackage hpstatus {}) 
-    hp-status-host-web;
-
+  inherit hpstatus;
   inherit (callPackage npm-to-nix {}) npmToNix;
   inherit (callPackage "${nixpkgs-mozilla}/package-set.nix" {}) rustChannelOf;
 

--- a/profiles/hydra/master/default.nix
+++ b/profiles/hydra/master/default.nix
@@ -100,6 +100,20 @@ in
         }
       '';
     };
+
+    virtualHosts.hpstatus = {
+      enableACME = true;
+      forceSSL = true;
+      root = pkgs.hp-status-host-web;
+      serverName = "hpstatus.holo.host";
+      extraConfig = ''
+        types {
+          application/javascript js;
+          text/css css;
+          text/html html;
+        }
+      '';
+    };
   };
 
   systemd.tmpfiles.rules = [

--- a/profiles/hydra/master/default.nix
+++ b/profiles/hydra/master/default.nix
@@ -106,13 +106,6 @@ in
       forceSSL = true;
       root = pkgs.hp-status-host-web;
       serverName = "hpstatus.holo.host";
-      extraConfig = ''
-        types {
-          application/javascript js;
-          text/css css;
-          text/html html;
-        }
-      '';
     };
   };
 

--- a/profiles/hydra/master/default.nix
+++ b/profiles/hydra/master/default.nix
@@ -104,7 +104,7 @@ in
     virtualHosts.hpstatus = {
       enableACME = true;
       forceSSL = true;
-      root = pkgs.hp-status-host-web;
+      root = pkgs.hpstatus;
       serverName = "hpstatus.holo.host";
     };
   };


### PR DESCRIPTION
Configure hydra to host hpstatus.holo.host. Needs updating to the right github.com/holo-host/hpstatus revision before merging.