### PR TITLE
README: update binary caches for consistency with #130

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ On NixOS, add the following to `/etc/nixos/configuration.nix` and rebuild:
 ```nix
 {
   nix.binaryCaches = [
-    "https://cache.holo.host"
+    "https://cache.holo.host/"
   ];
 
   nix.binaryCachePublicKeys = [
@@ -25,12 +25,12 @@ On NixOS, add the following to `/etc/nixos/configuration.nix` and rebuild:
 }
 ```
 
-Otherwise, add `https://cache.holo.host` to `substituters` and
+Otherwise, add `https://cache.holo.host/` to `substituters` and
 `cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE=` to
 `trusted-public-keys` in Nix config file:
 
 ```
-substituters = https://cache.holo.host https://cache.nixos.org
+substituters = https://cache.holo.host/ https://cache.nixos.org/
 trusted-public-keys = cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 ```
 


### PR DESCRIPTION
See #130. Since it was decided that `https://cache.nixos.org/` is to stay, it was updated accordingly in Holo Nixpkgs docs and `https://cache.holo.host` was changed to `https://cache.holo.host/` for consistency.