### PR TITLE
Add some documentation and scripting to assist testers in running aarch64 VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,10 @@ https://hydra.holo.host/job/holo-nixpkgs/master/holoportos.targets.virtualbox.x8
 Refer to [VirtualBox manual, chapter 1, section 1.15.2](https://www.virtualbox.org/manual/ch01.html#ovf-import-appliance).
 
 [nix]: https://nixos.org/nix/
+
+#### QEMU aarch64
+
+You can set up an arm64 image using qemu; see (aarch64-qemu.sh).  Derived from:
+
+http://www.redfelineninja.org.uk/daniel/2018/02/running-an-iso-installer-image-for-arm64-aarch64-using-qemu-and-kvm/
+

--- a/aarch64-qemu.sh
+++ b/aarch64-qemu.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# 
+# Run a Debian Installer iso, then boot
+# 
+# See: http://www.redfelineninja.org.uk/daniel/2018/02/running-an-iso-installer-image-for-arm64-aarch64-using-qemu-and-kvm/
+#
+# $ wget https://cdimage.debian.org/debian-cd/current/arm64/iso-cd/debian-10.1.0-arm64-netinst.iso
+# $ wget http://snapshots.linaro.org/components/kernel/leg-virt-tianocore-edk2-upstream/latest/QEMU-AARCH64/RELEASE_GCC5/QEMU_EFI.img.gz
+# $ gunzip QEMU_EFI.img.gz
+# $ qemu-img create -f qcow2 aarch64-debian.img 128G
+# $ qemu-img create -f qcow2 aarch64-varstore.img 64M
+# 
+# When installing, in the "Detect and mount CD-ROM":
+# 
+# - Load CD-ROM drivers from removable media?: Select No
+# - Manually select a CD-ROM module and device?: Select Yes
+# - Module needed for accessing the CD-ROM: Select none
+# - Device file for accessing the CD-ROM: Enter /dev/vdb and press Continue
+#
+
+SMP="-smp 8"
+# SSH to qumu host on localhost:2222
+NET="-device e1000,netdev=net0 -netdev user,id=net0,hostfwd=tcp::2222-:22"
+CPU="-cpu cortex-a53 -M virt -m 4096 -nographic"
+EFI="-drive if=pflash,format=raw,file=QEMU_EFI.img"
+VAR="-drive if=pflash,file=aarch64-varstore.img"
+IMG="-drive if=virtio,file=aarch64-debian.img"
+# Add this back in, to configure a QEMU booting from the installer ISO:
+ISO="-drive if=virtio,format=raw,file=debian-10.1.0-arm64-netinst.iso"
+
+qemu-system-aarch64 $SMP $NET $CPU $EFI $VAR $IMG # $ISO


### PR DESCRIPTION
Figuring out how to set up and run an ARM64 VM isn't trivial; since we need to do that in order to effectively develop for the HoloPort Nano, add some documentation and scripting to help.  I've been successfully running an aarch64 Debian VM for some time using these instructions and scripting.