### PR TITLE
Fix holo auth

### DIFF
--- a/modules/services/holo-auth-client.nix
+++ b/modules/services/holo-auth-client.nix
@@ -35,6 +35,8 @@ in
           zerotier-cli -j listnetworks | jq -r .[0].status
         }
 
+        sleep 10
+
         echo >&2 "Zerotier status, start: $(zerotier_status)"
 
         while [ "$(zerotier_status)" = "REQUESTING_CONFIGURATION" ]; do


### PR DESCRIPTION
o Await availability of root console, for `wall` communication
o Always run the holo-init and derive-keystore
o Ensure conductor requires/after holo-auth-client