### PR TITLE
.github: set up declarative GitHub repo settings via https://github.com/probot/settings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+.github/ @samrose @yegortimoshenko
+modules/ @yegortimoshenko
+profiles/ @yegortimoshenko

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,56 @@
+repository:
+  name: holo-nixpkgs
+  description: Modules, packages and profiles that drive Holo, Holochain and HoloPortOS
+  topics: holo, holochain, nix, nixos
+  private: false
+  has_issues: true
+  has_projects: false
+  has_wiki: false
+  default_branch: develop
+  allow_squash_merge: false
+  allow_merge_commit: false
+  allow_rebase_merge: false
+
+collaborators: []
+
+teams:
+  - name: central
+    permission: push
+  - name: hydra
+    permission: push
+
+branches:
+  - name: develop
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        dismissal_restrictions:
+          users: []
+          teams: []
+      required_status_checks:
+        strict: true
+        contexts:
+          - Hydra
+      enforce_admins: true
+      restrictions:
+        users: []
+        teams: []
+  - name: master
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        dismissal_restrictions:
+          users: []
+          teams: []
+      required_status_checks:
+        strict: true
+        contexts:
+          - Hydra
+      enforce_admins: true
+      restrictions:
+        users: []
+        teams: []


### PR DESCRIPTION
See: https://github.com/probot/settings

Note that this also adds `CODEOWNERS` file with me being a codeowner for `modules/` and `profiles/`. Read more about code owners here: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners