### PR TITLE
hp-admin-crypto-server: init

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -11,6 +11,7 @@
     ./services/holo-router-agent.nix
     ./services/holo-router-gateway.nix
     ./services/holochain-conductor.nix
+    ./services/hp-admin-crypto-server.nix
     ./services/hpos-admin.nix
     ./system/holoportos.nix
     ./system/holoportos/auto-upgrade.nix

--- a/modules/services/hp-admin-crypto-server.nix
+++ b/modules/services/hp-admin-crypto-server.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.hp-admin-crypto-server;
+in
+
+{
+  options.services.hp-admin-crypto-server = {
+    enable = mkEnableOption "HP Admin Crypto server";
+
+    package = mkOption {
+      default = pkgs.hp-admin-crypto-server;
+      type = types.package;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.hp-admin-crypto-server = {
+      after = [ "holo-auth-client.service" ];
+      requires = [ "holo-auth-client.service" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.hpos-init ];
+
+      script = ''
+        HPOS_STATE_PATH=$(hpos-init) ${cfg.package}/bin/hp-admin-crypto-server
+      '';
+
+      serviceConfig.User = "root";
+    };
+  };
+}

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -55,6 +55,13 @@ let
     sha256 = "1abna46da9av059kfy10ls0fa6ph8vhh75rh8cv3mvi96m2n06zd";
   };
 
+  hp-admin-crypto = fetchFromGitHub {
+    owner = "Holo-Host";
+    repo = "hp-admin-crypto";
+    rev = "1e9d8fad9382343153497ff2a673f62357dfa066";
+    sha256 = "0ssxra8i7kx7bp6mjs6rmi24qj3jf6zrqp4kz5x0sbqxah23742p";
+  };
+
   hpos-state = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hpos-state";
@@ -94,6 +101,8 @@ in
     hp-admin-ui
     holofuel-ui
     ;
+
+  inherit (callPackage hp-admin-crypto {}) hp-admin-crypto-server;
 
   inherit (callPackage hpos-state {})
     hpos-state-derive-keystore

--- a/profiles/holoportos/default.nix
+++ b/profiles/holoportos/default.nix
@@ -53,6 +53,8 @@ in
 
   services.holo-router-agent.enable = true;
 
+  services.hp-admin-crypto-server.enable = true;
+
   services.hpos-admin.enable = true;
 
   services.mingetty.autologinUser = "root";


### PR DESCRIPTION
Integrates HP Admin crypto server into HoloPortOS. cc @peeech 