### PR TITLE
Build all DNAs using holo-nixpkgs buildDNA

### DIFF
--- a/overlays/holo-nixpkgs/build-dna/default.nix
+++ b/overlays/holo-nixpkgs/build-dna/default.nix
@@ -98,13 +98,16 @@ rustPlatform.buildRustPackage (
 
     checkPhase = ''
       runHook preCheck
-    '' + optionalString (pathExists (stripContext testDir)) ''
+
       cargo test
-      # TODO: When we are able to again perform DNA end-to-end tests, do so here, eg.:
-      #cp -r ${npmToNix { src = testDir; }} test/node_modules
-      #sim2h_server -p 9000 &
-      #hc test | ( node test/node_modules/faucet/bin/cmd.js || cat )
+
+    '' + optionalString (pathExists (stripContext testDir)) ''
+      cp -r ${npmToNix { src = testDir; }} test/node_modules
+      # TODO: when "memory" tests are reliable, re-enable
+      #APP_SPEC_NETWORK_TYPE=memory hc test \
+      #    | ( node test/node_modules/faucet/bin/cmd.js || cat )
     '' + ''
+
       runHook postCheck
     '';
 

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -116,6 +116,7 @@ in
     callPackage ./build-dna {
       inherit (llvmPackages_8) lld;
       inherit (rust.packages.nightly) rustPlatform;
+      nodejs = nodejs-12_x;
     }
   );
 
@@ -168,6 +169,7 @@ in
   );
 
   dnaPackages = recurseIntoAttrs {
+    happ-example = callPackage ./dna-packages/happ-example {};
     happ-store = callPackage ./dna-packages/happ-store {};
     holo-hosting-app = callPackage ./dna-packages/holo-hosting-app {};
     holofuel = callPackage ./dna-packages/holofuel {};

--- a/overlays/holo-nixpkgs/dna-packages/happ-example/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/happ-example/default.nix
@@ -1,0 +1,12 @@
+{ callPackage, fetchFromGitHub }:
+
+let
+  src = fetchFromGitHub {
+    owner = "Holo-Host";
+    repo = "happ-example";
+    rev = "4ed567d213897ea81c6db194f85e9ba6afdd68b7";
+    sha256 = "1frz99r64nfqcfbwj4lybji3jzjha7lwpi9zy9c8bik5v7n81ic0";
+  };
+in
+
+(callPackage src {}).happ-example

--- a/overlays/holo-nixpkgs/dna-packages/happ-store/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/happ-store/default.nix
@@ -1,13 +1,12 @@
-{ runCommand, fetchurl }:
+{ callPackage, fetchFromGitHub }:
 
 let
-  src = fetchurl {
-    url = "https://github.com/holochain/happ-store/releases/download/v0.4.1-alpha1/hApp-store.dna.json";
-    name = "happ-store.dna.json";
-    sha256 = "1y89q052y6nbm70akdb2qfbkc7yj73xla4qjw2lmk0b76g06l0r8";
+  src = fetchFromGitHub {
+    owner = "holochain";
+    repo = "happ-store";
+    rev = "4e27b888810b45d706b2982f7d97aa454aaf74cf";
+    sha256 = "18h0x2m5vnmm1xz5k0j7rsc4il62vhq29qcl7wn1f9vmsfac2lrv";
   };
 in
 
-runCommand "happ-store" {} ''
-  install -D ${src} $out/${src.name}
-''
+(callPackage src {}).happ-store

--- a/overlays/holo-nixpkgs/dna-packages/holo-hosting-app/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/holo-hosting-app/default.nix
@@ -1,13 +1,12 @@
-{ runCommand, fetchurl }:
+{ callPackage, fetchFromGitHub }:
 
 let
-  src = fetchurl {
-    url = "https://github.com/Holo-Host/holo-hosting-app/releases/download/v0.4.1-alpha1/holo-hosting-app.dna.json";
-    name = "holo-hosting-app.dna.json";
-    sha256 = "0yxky5g6lb84g4zffqsmahdffz1drq9dqywsvgbzqxilwhsgm2cj";
+  src = fetchFromGitHub {
+    owner = "Holo-Host";
+    repo = "holo-hosting-app";
+    rev = "bbda39876d5bc206712fcbe27fdb5e405006e539";
+    sha256 = "0wf7133cam8s3m6hww5fk29343z2a0xf2qv764radx5pcr02lhs0";
   };
 in
 
-runCommand "holo-hosting-app" {} ''
-  install -D ${src} $out/${src.name}
-''
+(callPackage src {}).holo-hosting-app

--- a/overlays/holo-nixpkgs/dna-packages/servicelogger/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/servicelogger/default.nix
@@ -4,8 +4,8 @@ let
   src = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "servicelogger";
-    rev = "5b96b9e507a6000b99f2e2473722e94412901990";
-    sha256 = "1if37bwlv32zdqxs0s6zb7bnymw4x6594aj694bhilbkkadg2wxj";
+    rev = "3b716c325e4243f5c88e2f65530cd6495a9f4ae5";
+    sha256 = "03izll3b5ajgbw9b6df7vxc68ysxd4xzbrw2p41r9ybgmnn9bii8";
   };
 in
 


### PR DESCRIPTION
Repackaged all DNAs to have a top-level Cargo.toml, and to support `cargo test`.

Until we can agree that e2e testing DNAs requires a local `sim2h` service to be running on either localhost:9000 or a UNIX-domain socket, we have removed `hc test` from the `buildDNA` process.

The most violent DNA repackaging changes occurred to `happ-store`, which had a non-standard multi-level directory structure, and was difficult (if not impossible) to handle in a sensible fashion.  This was repackaged to A) move `cargo test` and `hc test` to the top level, and rename the output DNA to `happ-store.dna.json` (instead of `hApp-store.dna.json`).