### PR TITLE
profiles/holoportos/demo: use sim2h for networking

### DIFF
--- a/profiles/holoportos/demo/default.nix
+++ b/profiles/holoportos/demo/default.nix
@@ -53,7 +53,8 @@ in
       dnas = map dnaConfig dnas;
       instances = map instanceConfig dnas;
       network = {
-        bootstrap_nodes = [];
+        type = "sim2h";
+        sim2h_url = "wss://sim2h.holochain.org:9000";
       };
       persistence_dir = conductorHome;
       signing_service_uri = "http://localhost:8888";


### PR DESCRIPTION
During early Open Alpha, we'll be using `sim2h` to provide DHT communications between nodes.

Default to the public `sim2h` server.

TODO: This resolves the "demo" branch; where else are we incorrectly assuming incorrect DHT configuration, eg. `n3h`?