### PR TITLE
profiles/hydra/master: add missing PNG, SVG MIME types for quickstart

### DIFF
--- a/profiles/hydra/master/default.nix
+++ b/profiles/hydra/master/default.nix
@@ -122,6 +122,8 @@ in
         types {
           application/javascript js;
           application/wasm wasm;
+          image/png png;
+          image/svg+xml svg;
           text/css css;
           text/html html;
         }


### PR DESCRIPTION
This fixes missing MIME type handling on <https://quickstart.holo.host> page that results in vector images not being displayed.

Before:

```
curl -I 'https://quickstart.holo.host/assets/icons/holo-logo-avatar.svg'
HTTP/2 200 
server: nginx
date: Fri, 13 Dec 2019 03:24:45 GMT
content-type: text/plain
content-length: 4398
last-modified: Thu, 01 Jan 1970 00:00:01 GMT
etag: "56g6n98zankv1zkhk9kc5ssnd5hf2ibv"
accept-ranges: bytes
```

After:

```
curl -I 'https://quickstart.holo.host/assets/icons/holo-logo-avatar.svg'
HTTP/2 200 
server: nginx
date: Fri, 13 Dec 2019 03:27:00 GMT
content-type: image/svg+xml
content-length: 4398
last-modified: Thu, 01 Jan 1970 00:00:01 GMT
etag: "56g6n98zankv1zkhk9kc5ssnd5hf2ibv"
accept-ranges: bytes
```