### PR TITLE
profiles/router-gateway: fix eval, implement HTTP -> HTTPS redirect

### DIFF
--- a/profiles/router-gateway/default.nix
+++ b/profiles/router-gateway/default.nix
@@ -14,8 +14,6 @@ with pkgs;
 
   networking.firewall.allowedTCPPorts = [ 80 443 ];
 
-  networking.hostName = "holoportos";
-
   security.sudo.wheelNeedsPassword = false;
 
   services.dnscrypt-proxy2 = {

--- a/profiles/router-gateway/default.nix
+++ b/profiles/router-gateway/default.nix
@@ -12,7 +12,7 @@ with pkgs;
 
   environment.systemPackages = [ pkgs.holo-router-gateway ];
 
-  networking.firewall.allowedTCPPorts = [ 443 ];
+  networking.firewall.allowedTCPPorts = [ 80 443 ];
 
   networking.hostName = "holoportos";
 
@@ -29,6 +29,15 @@ with pkgs;
   services.holo-router-gateway.enable = true;
 
   services.mingetty.autologinUser = "root";
+
+  services.nginx = {
+    enable = true;
+    virtualHosts.default = {
+      extraConfig = ''
+        return 301 https://$host$request_uri;
+      '';
+    };
+  };
 
   users.users.root.openssh.authorizedKeys.keys = lib.mkForce [
     # Sam Rose


### PR DESCRIPTION
This allows Holo Router to correctly route ACME challenge so that HPOS can get a Let's Encrypt signed TLS certificate.