### PR TITLE
profiles/hardware/virtualbox: bump default RAM to 3GB

### DIFF
--- a/profiles/hardware/virtualbox/default.nix
+++ b/profiles/hardware/virtualbox/default.nix
@@ -11,6 +11,8 @@ in
 
   system.holoportos.target = "virtualbox";
 
+  virtualbox.memorySize = 3072;
+
   virtualbox.vmFileName =
     "holoportos-for-${config.system.holoportos.target}.ova";
 


### PR DESCRIPTION
`hpos-state-derive-keystore` and `holo-router-agent` need at least 3GB RAM to reliably run.

cc @alastairong 