### PR TITLE
modules/system/holoportos: ignore network option

### DIFF
--- a/modules/system/holoportos.nix
+++ b/modules/system/holoportos.nix
@@ -3,14 +3,9 @@
 with lib;
 
 {
-  imports = [
-    (
-      mkRemovedOptionModule [ "system" "holoportos" "network" ]
-        "Holo ZeroTier networks were merged together as of 2019-11-11."
-    )
-  ];
-
   options.system.holoportos = {
+    network = mkOption {};
+
     target = mkOption {
       default = "generic";
     };


### PR DESCRIPTION
NixOS/nixpkgs@b08b0bcbbec77046e5a7082177cedc12fbf1dc6c broke the original code, so we're going to go with empty mkOption no-op.