### PR TITLE
profiles/holoportos: add hylo-holo-dnas (Communities) DNA

### DIFF
--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -23,6 +23,13 @@ let
     sha256 = "0wf7133cam8s3m6hww5fk29343z2a0xf2qv764radx5pcr02lhs0";
   };
 
+  hylo-holo-dnas = fetchFromGitHub {
+    owner = "holochain";
+    repo = "hylo-holo-dnas";
+    rev = "b1d07d4669a7c0e317de2cf0034960fc094e19b1";
+    sha256 = "1hn1x16a7lxrp879vxg8imd5l7kkvg1pdqb9fr1v2jjcfdx7j943";
+  };
+
   servicelogger = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "servicelogger";
@@ -35,6 +42,8 @@ in
   inherit (callPackage happ-store {}) happ-store;
 
   inherit (callPackage holo-hosting-app {}) holo-hosting-app;
+
+  inherit (callPackage hylo-holo-dnas {}) hylo-holo-dnas;
 
   inherit (callPackage servicelogger {}) servicelogger;
 

--- a/profiles/holoportos/default.nix
+++ b/profiles/holoportos/default.nix
@@ -10,6 +10,7 @@ let
   dnas = with dnaPackages; [
     happ-store
     holo-hosting-app
+    hylo-holo-dnas
     holofuel
     servicelogger
   ];

--- a/tests/holochain-conductor/default.nix
+++ b/tests/holochain-conductor/default.nix
@@ -31,7 +31,7 @@ makeTest {
     $machine->waitForUnit("holochain-conductor.service");
     $machine->waitForOpenPort("42211");
 
-    my $expected_dnas = "happ-store\nholo-hosting-app\nholofuel\nservicelogger\n";
+    my $expected_dnas = "happ-store\nholo-hosting-app\nhylo-holo-dnas\nholofuel\nservicelogger\n";
     my $actual_dnas = $machine->succeed(
       "holo admin --port 42211 interface | jq -r '.[2].instances[].id'"
     );


### PR DESCRIPTION
I think we should change the name to `communities` from `hylo-holo-dnas`