### PR TITLE
Revert "nixpkgs: update to cc6cf0a96a627e678ffc996a8f9d1416200d6c81"

### DIFF
--- a/nixpkgs/ext4-no-resize2fs.diff
+++ b/nixpkgs/ext4-no-resize2fs.diff
@@ -1,8 +1,8 @@
 diff --git a/nixos/lib/make-ext4-fs.nix b/nixos/lib/make-ext4-fs.nix
-index 932adcd9796..d5a995c2a6e 100644
+index 47c6374c81a..2d5948424c1 100644
 --- a/nixos/lib/make-ext4-fs.nix
 +++ b/nixos/lib/make-ext4-fs.nix
-@@ -82,7 +82,6 @@ pkgs.stdenv.mkDerivation {
+@@ -67,7 +67,6 @@ pkgs.stdenv.mkDerivation {
          size=$(( blocks - ''${free##*:} + fudge ))
  
          echo "Resizing from $blocks blocks to $size blocks. (~ $((size*blocksize/1024/1024))MiB)"

--- a/nixpkgs/source-original.nix
+++ b/nixpkgs/source-original.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/cc6cf0a96a627e678ffc996a8f9d1416200d6c81.tar.gz";
-  sha256 = "1srjikizp8ip4h42x7kr4qf00lxcp1l8zp6h0r1ddfdyw8gv9001";
+  url = "https://github.com/NixOS/nixpkgs/archive/5f506b95f9f6290f4c46f523cc3f5cef581c5666.tar.gz";
+  sha256 = "14ry2fs2pny2shlg2dq8c9vns636gv0zvfh0dmyy4bnq713k377n";
 }


### PR DESCRIPTION
Reverts Holo-Host/holo-nixpkgs#238. Hydra doesn't start, see https://github.com/NixOS/nixpkgs/issues/72783.