### PR TITLE
holochain-rust: bump to v0.0.42-alpha4

### DIFF
--- a/modules/services/holochain-conductor.nix
+++ b/modules/services/holochain-conductor.nix
@@ -17,24 +17,17 @@ in
     };
 
     package = mkOption {
-      default = pkgs.holochain-conductor;
+      default = pkgs.holochain-rust;
       type = types.package;
     };
   };
 
   config = mkIf (cfg.enable) {
-    environment.systemPackages = with pkgs; [
-      holochain-cli
-    ];
+    environment.systemPackages = [ cfg.package ];
 
     systemd.services.holochain-conductor = {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-
-      path = with pkgs; [
-        holochain-cli
-        holochain-conductor
-      ];
 
       preStart = ''
         cat ${pkgs.writeTOML cfg.config} > ${home}/conductor-config.toml

--- a/modules/services/sim2h-server.nix
+++ b/modules/services/sim2h-server.nix
@@ -11,7 +11,7 @@ in
     enable = mkEnableOption "Holo Envoy";
 
     package = mkOption {
-      default = pkgs.sim2h-server;
+      default = pkgs.holochain-rust;
       type = types.package;
     };
 

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -32,13 +32,6 @@ let
     sha256 = "0j9fpm51wr0lb22g7qsilmasb4gi21yyqscdgp3szk9bb5q83alq";
   };
 
-  holochain-rust = fetchFromGitHub {
-    owner = "holochain";
-    repo = "holochain-rust";
-    rev = "e33624e0e3cb23158212590ee89d6aaa7ca86e2e";
-    sha256 = "1bjkl623r0y2ybibnxma2j1mp8rhr3zwav96f9jq34f2vqyw0vj8";
-  };
-
   hp-admin = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hp-admin";
@@ -162,7 +155,7 @@ in
 
   dnaHash = dna: builtins.readFile (
     runCommand "${dna.name}-hash" {} ''
-      ${holochain-cli}/bin/hc hash -p ${dna}/${dna.name}.dna.json \
+      ${holochain-rust}/bin/hc hash -p ${dna}/${dna.name}.dna.json \
         | tail -1 \
         | cut -d ' ' -f 3- \
         | tr -d '\n' > $out
@@ -172,12 +165,6 @@ in
   dnaPackages = recurseIntoAttrs (
     import ./dna-packages final previous
   );
-
-  inherit (callPackage holochain-rust {})
-    holochain-cli
-    holochain-conductor
-    sim2h-server
-    ;
 
   holo = recurseIntoAttrs {
     buildProfile = profile: buildImage [
@@ -204,6 +191,11 @@ in
   holo-nixpkgs-tests = recurseIntoAttrs (
     import "${holo-nixpkgs.path}/tests" { inherit pkgs; }
   );
+
+  holochain-rust = callPackage ./holochain-rust {
+    inherit (darwin.apple_sdk.frameworks) CoreServices Security;
+    inherit (rust.packages.nightly) rustPlatform;
+  };
 
   holoport-nano-dtb = callPackage ./holoport-nano-dtb {
     linux = linux_latest;

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -84,10 +84,9 @@ in
     holo-router-gateway
     ;
 
-  inherit (callPackage hp-admin {})
-    hp-admin-ui
-    holofuel-ui
-    ;
+  hp-admin-ui = runCommand "hp-admin-ui" {} ''
+    mkdir $out
+  '';
 
   inherit (callPackage hp-admin-crypto {}) hp-admin-crypto-server;
 

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -283,8 +283,8 @@ in
         rustc = (
           rustChannelOf {
             channel = "nightly";
-            date = "2019-07-14";
-            sha256 = "1llbwkjkjis6rv0rbznwwl0j6bf80j38xgwsd4ilcf0qps4cvjsx";
+            date = "2019-11-16";
+            sha256 = "17l8mll020zc0c629cypl5hhga4hns1nrafr7a62bhsp4hg9vswd";
           }
         ).rust.override {
           targets = [

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -28,8 +28,8 @@ let
   holo-router = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-router";
-    rev = "f6c5be74307b29689d1d2bb939c9c5ca44c6ca91";
-    sha256 = "0j9fpm51wr0lb22g7qsilmasb4gi21yyqscdgp3szk9bb5q83alq";
+    rev = "9390a905e31f05a7b9d17f8463a04096c507b712";
+    sha256 = "1yiknzb1k1l57ri60nmpfgg9q159f8dzb84ljmqd2b2qx8jg0zc7";
   };
 
   hp-admin = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -49,8 +49,8 @@ let
   hpos-config = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hpos-config";
-    rev = "a64da0d9bc0ef87bc358fcdad6323b424cf4971b";
-    sha256 = "1059lfr2vnacq3aghmir007vgql4za197xx2qlm732vhb6svgpma";
+    rev = "eb256e2243e08546b078c106541671fb4d4aa61d";
+    sha256 = "0ldbvrda016aha0p55k1nzqb6636micc0x7xf2ffkqn96fz6d6ly";
   };
 
   nixpkgs-mozilla = fetchTarball {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -6,8 +6,8 @@ let
   happ-store = fetchFromGitHub {
     owner = "holochain";
     repo = "happ-store";
-    rev = "4e27b888810b45d706b2982f7d97aa454aaf74cf";
-    sha256 = "18h0x2m5vnmm1xz5k0j7rsc4il62vhq29qcl7wn1f9vmsfac2lrv";
+    rev = "11b4a43e4fe12c71e1efc3a19ccfab021bc8ede9";
+    sha256 = "07azyb4gspabh13h9cxwkpmlissqah88viy7m6dmq0sh0cdbir7k";
   };
 
   holofuel = fetchurl {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -19,8 +19,8 @@ let
   holo-hosting-app = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-hosting-app";
-    rev = "bbda39876d5bc206712fcbe27fdb5e405006e539";
-    sha256 = "0wf7133cam8s3m6hww5fk29343z2a0xf2qv764radx5pcr02lhs0";
+    rev = "da3f1c4efdf6634fe8ca255ff0baf399c2f4fbb4";
+    sha256 = "1jlx1992zc9xc1gc12iqy409qf1nakpmsrn0lrr97p76r55igacz";
   };
 
   holo-communities-dna = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -11,9 +11,9 @@ let
   };
 
   holofuel = fetchurl {
-    url = "https://holo-host.github.io/holofuel/releases/download/v0.13.1-alpha1/holofuel.dna.json";
+    url = "https://holo-host.github.io/holofuel/releases/download/v0.14.1-alpha1/holofuel.dna.json";
     name = "holofuel.dna.json";
-    sha256 = "10xmq52m37r09flmsri64iwrpi9l88s9zmdl50l346ld6rxd0jf8";
+    sha256 = "0bkixlh5ass5p9xzi4hh31z2lyw29qbn742fmnlbl6zi6y5qrsjd";
   };
 
   holo-hosting-app = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -23,12 +23,12 @@ let
     sha256 = "0wf7133cam8s3m6hww5fk29343z2a0xf2qv764radx5pcr02lhs0";
   };
 
-  hylo-holo-dnas = fetchFromGitHub {
-    owner = "holochain";
-    repo = "hylo-holo-dnas";
-    rev = "b1d07d4669a7c0e317de2cf0034960fc094e19b1";
-    sha256 = "1hn1x16a7lxrp879vxg8imd5l7kkvg1pdqb9fr1v2jjcfdx7j943";
-  };
+  holo-communities-dna = fetchFromGitHub {
+    owner = "Holo-Host";
+    repo = "holo-communities-dna";
+    rev = "97fde88d03e5c5d702545e01d67046bf64cbbace";
+    sha256 = "0127gawjkh36kgnnmb2lv26q5x5hczlky4wlv46sjc05x21cnyli";
+   };
 
   servicelogger = fetchFromGitHub {
     owner = "Holo-Host";
@@ -43,7 +43,7 @@ in
 
   inherit (callPackage holo-hosting-app {}) holo-hosting-app;
 
-  inherit (callPackage hylo-holo-dnas {}) hylo-holo-dnas;
+  inherit (callPackage holo-communities-dna {}) holo-communities-dna;
 
   inherit (callPackage servicelogger {}) servicelogger;
 

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -26,8 +26,8 @@ let
   holo-communities-dna = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-communities-dna";
-    rev = "97fde88d03e5c5d702545e01d67046bf64cbbace";
-    sha256 = "0127gawjkh36kgnnmb2lv26q5x5hczlky4wlv46sjc05x21cnyli";
+    rev = "53f204094e35f21bdd5009ed43cc16b093560737";
+    sha256 = "0jyjj1762d905ysgkhg3p062vp9rmx552nb87z6n4vb11lm3hhh6";
    };
 
   servicelogger = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -33,8 +33,8 @@ let
   servicelogger = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "servicelogger";
-    rev = "3b716c325e4243f5c88e2f65530cd6495a9f4ae5";
-    sha256 = "03izll3b5ajgbw9b6df7vxc68ysxd4xzbrw2p41r9ybgmnn9bii8";
+    rev = "389d6f7c1f0bb4e514a9d4ea56d5220992abed89";
+    sha256 = "13q78mc33h3d4rvmbh7sqzh8rlpxf895b656jji4g74m1ps1cd10";
   };
 in
 

--- a/overlays/holo-nixpkgs/holochain-rust/default.nix
+++ b/overlays/holo-nixpkgs/holochain-rust/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, rustPlatform, fetchFromGitHub, perl, CoreServices, Security, libsodium }:
+
+rustPlatform.buildRustPackage {
+  name = "holochain-rust";
+
+  src = fetchFromGitHub {
+    owner = "holochain";
+    repo = "holochain-rust";
+    rev = "v0.0.42-alpha4";
+    sha256 = "0c2igvnmjh4l2gr8xq1pllxjniy03c30rsgwrm4lf5qjmn14ibp4";
+  };
+
+  cargoSha256 = "1cfk2z4pbk8dli31wpplczd8a1fy8fyhwa5rsl6yz3jzw9d2kdkk";
+
+  nativeBuildInputs = [ perl ];
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [
+    CoreServices
+    Security
+  ];
+
+  RUST_SODIUM_LIB_DIR = "${libsodium}/lib";
+  RUST_SODIUM_SHARED = "1";
+
+  doCheck = false;
+}

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -25,7 +25,7 @@ let
   dnas = with dnaPackages; [
     happ-store
     holo-hosting-app
-    hylo-holo-dnas
+    holo-communities-dna
     holofuel
     servicelogger
   ];

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -127,13 +127,6 @@ in
           '';
         };
 
-        "/holofuel/" = {
-          alias = "${pkgs.holofuel-ui}/";
-          extraConfig = ''
-            limit_req zone=zone1 burst=30;
-          '';
-        };
-
         "/v1/hosting/" = {
           proxyPass = "http://127.0.0.1:4656";
           proxyWebsockets = true;

--- a/tests/holochain-conductor/default.nix
+++ b/tests/holochain-conductor/default.nix
@@ -31,7 +31,7 @@ makeTest {
     $machine->waitForUnit("holochain-conductor.service");
     $machine->waitForOpenPort("42211");
 
-    my $expected_dnas = "happ-store\nholo-hosting-app\nhylo-holo-dnas\nholofuel\nservicelogger\n";
+    my $expected_dnas = "happ-store\nholo-hosting-app\nholo-communities-dna\nholofuel\nservicelogger\n";
     my $actual_dnas = $machine->succeed(
       "holo admin --port 42211 interface | jq -r '.[2].instances[].id'"
     );


### PR DESCRIPTION
DNAs and dependent packages updated to holochain-rust 0.0.41-alpha4, via their respective `release-0.0.41-alpha4-holo-nixpkgs` branches.

Run `nix-shell` and `hpos-shell`


