### PR TITLE
magic-wormhole-mailbox-server: init at 0.4.1

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -13,6 +13,7 @@
     ./services/holochain-conductor.nix
     ./services/hp-admin-crypto-server.nix
     ./services/hpos-admin.nix
+    ./services/magic-wormhole-mailbox-server.nix
     ./services/sim2h-server.nix
     ./system/holoportos.nix
     ./system/holoportos/auto-upgrade.nix

--- a/modules/services/magic-wormhole-mailbox-server.nix
+++ b/modules/services/magic-wormhole-mailbox-server.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.magic-wormhole-mailbox-server;
+  pkg = pkgs.magic-wormhole-mailbox-server;
+
+  python = pkg.passthru.python.withPackages (py: [ pkg py.twisted ]);
+in
+
+{
+  options.services.magic-wormhole-mailbox-server = {
+    enable = mkEnableOption "Magic Wormhole Mailbox Server";
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.magic-wormhole-mailbox-server = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig.ExecStart = "${python}/bin/twistd --nodaemon wormhole-mailbox";
+    };
+  };
+}

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -272,6 +272,8 @@ in
     }
   );
 
+  magic-wormhole-mailbox-server = python3Packages.callPackage ./magic-wormhole-mailbox-server {};
+
   nodejs = nodejs-12_x;
 
   rust = previous.rust // {

--- a/overlays/holo-nixpkgs/magic-wormhole-mailbox-server/default.nix
+++ b/overlays/holo-nixpkgs/magic-wormhole-mailbox-server/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage
+, fetchPypi
+, python
+, autobahn
+, mock
+, pyopenssl
+, service-identity
+, treq
+, twisted
+}:
+
+buildPythonPackage rec {
+  pname = "magic-wormhole-mailbox-server";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1yw8i8jv5iv1kkz1aqimskw7fpichjn6ww0fq0czbalwj290bw8s";
+  };
+
+  passthru = { inherit python; };
+
+  propagatedBuildInputs = [
+    autobahn
+    mock
+    pyopenssl
+    service-identity
+    treq
+    twisted
+  ];
+}


### PR DESCRIPTION
This is a service that can be used to set up a Wormhole relay. This is required to run [HPOS Seed](https://github.com/Holo-Host/hpos-seed) integration tests. Additionally, maybe we should self-host our own, especially given that we are now using a custom Wormhole App ID.