### PR TITLE
holo-nixpkgs-tests -> holo-nixpkgs.tests, holo-nixpkgs.path: init

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -201,11 +201,11 @@ in
 
   holo-cli = callPackage ./holo-cli {};
 
-  holo-nixpkgs-tests = recurseIntoAttrs (
-    import ../../tests {
-      inherit pkgs;
-    }
-  );
+  holo-nixpkgs = recurseIntoAttrs {
+    tests = recurseIntoAttrs (
+      import ../../tests { inherit pkgs; }
+    );
+  };
 
   holoportos = recurseIntoAttrs {
     profile = tryDefault <nixos-config> ../../profiles/holoportos;

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -202,6 +202,8 @@ in
   holo-cli = callPackage ./holo-cli {};
 
   holo-nixpkgs = recurseIntoAttrs {
+    path = gitignoreSource ../..;
+
     tests = recurseIntoAttrs (
       import ../../tests { inherit pkgs; }
     );


### PR DESCRIPTION
`holo-nixpkgs.path`, makes downstream NixOS tests possible. `holo-nixpkgs-tests` was renamed to try to refine idioms in Holo Nixpkgs and make it easier to reason about.