### PR TITLE
mkJobsets: init

### DIFF
--- a/jobsets.nix
+++ b/jobsets.nix
@@ -2,44 +2,9 @@
 
 with pkgs;
 
-let
-  pullRequests = lib.importJSON <holo-nixpkgs-pull-requests>;
-
-  sharedJobset = {
-    checkinterval = 10;
-    emailoverride = "";
-    enabled = true;
-    enableemail = false;
-    hidden = false;
-    keepnr = 512;
-    nixexprinput = "holo-nixpkgs";
-    nixexprpath = "release.nix";
-  };
-
-  branchJobset = ref: sharedJobset // {
-    inputs.holo-nixpkgs = {
-      emailresponsible = false;
-      type = "git";
-      value = "https://github.com/Holo-Host/holo-nixpkgs.git ${ref}";
-    };
-    schedulingshares = 60;
-  };
-
-  pullRequestToJobset = n: pr: sharedJobset // {
-    inputs.holo-nixpkgs = {
-      emailresponsible = false;
-      type = "git";
-      value = "https://github.com/${pr.base.repo.owner.login}/${pr.base.repo.name} pull/${n}/head";
-    };
-    schedulingshares = 20;
-  };
-
-  jobsets = lib.mapAttrs pullRequestToJobset pullRequests // {
-    develop = branchJobset "develop";
-    master = branchJobset "master";
-  };
-in
-
-{
-  jobsets = pkgs.writeText "jobsets.json" (builtins.toJSON jobsets);
+mkJobsets {
+  owner = "Holo-Host";
+  repo = "holo-nixpkgs";
+  branches = [ "develop" "master" ];
+  pullRequests = <holo-nixpkgs-pull-requests>;
 }

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -136,6 +136,8 @@ in
     in
       head (attrVals imageNames system);
 
+  mkJobsets = callPackage ./mk-jobsets {};
+
   singletonDir = path:
     let
       drv = lib.toDerivation path;

--- a/overlays/holo-nixpkgs/mk-jobsets/default.nix
+++ b/overlays/holo-nixpkgs/mk-jobsets/default.nix
@@ -1,0 +1,38 @@
+{ lib, writeText }: { owner, repo, branches, pullRequests }:
+
+let
+  toJobset = { url, ref }: {
+    checkinterval = 10;
+    emailoverride = "";
+    enabled = true;
+    enableemail = false;
+    hidden = false;
+    inputs."${repo}" = {
+      emailresponsible = false;
+      type = "git";
+      value = "${url} ${ref}";
+    };
+    keepnr = 65535;
+    nixexprinput = repo;
+    nixexprpath = "release.nix";
+    schedulingshares = 100;
+  };
+
+  branchToJobset = ref: toJobset {
+    url = "https://github.com/${owner}/${repo}.git";
+    inherit ref;
+  };
+
+  pullRequestToJobset = n: pr: toJobset {
+    url = "https://github.com/${pr.base.repo.owner.login}/${pr.base.repo.name}.git";
+    ref = "pull/${n}/head";
+  };
+
+  jobsets =
+    lib.mapAttrs pullRequestToJobset (lib.importJSON pullRequests) //
+    lib.genAttrs branches branchToJobset;
+in
+
+{
+  jobsets = writeText "jobsets.json" (builtins.toJSON jobsets);
+}


### PR DESCRIPTION
Resolves #182. Usage example:

```nix
{ pkgs ? import ./nixpkgs.nix {} }: with pkgs;

mkJobsets {
  owner = "Holo-Host";
  repo = "hpos-seed";
  # Branches to track and build in Hydra
  branches = [ "develop" "master" ];
  # Boilerplate, always <project-name-pull-requests>
  pullRequests = <hpos-seed-pull-requests>;
}
```

cc @samrose @zo-el 