### PR TITLE
mkBuildMatrix: init

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -136,6 +136,9 @@ in
     in
       head (attrVals imageNames system);
 
+  mkBuildMatrix = scope:
+    lib.mapAttrs (_: pkgs: scope { inherit pkgs; });
+
   mkJobsets = callPackage ./mk-jobsets {};
 
   singletonDir = path:


### PR DESCRIPTION
Overall this is based on Nix build compatible Holochain build system that I've authored a while ago. It should prove to be very useful for setting up Hydra-based downstream CI.

Usage example:

```nix
let
  overlay = final: _: import ./. { pkgs = final; };

  nixpkgs = args: import ./nixpkgs.nix (args // {
    overlays = [ overlay ];
  });
in

with nixpkgs {};

mkBuildMatrix {
  inherit overlay;

  platforms = {
    aarch64-linux-gnu-native = nixpkgs { system = "aarch64-linux"; };
    x86_64-darwin-native = nixpkgs { system = "x86_64-darwin"; };
    x86_64-linux-gnu-native = nixpkgs { system = "x86_64-linux"; };
  };
}
```