### PR TITLE
mkRelease: init

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -141,6 +141,22 @@ in
 
   mkJobsets = callPackage ./mk-jobsets {};
 
+  mkRelease = src: platforms:
+    let
+      buildMatrix = mkBuildMatrix (import src) platforms;
+    in
+    {
+      aggregate = releaseTools.channel {
+        name = "aggregate";
+        inherit src;
+
+        constituents = with lib;
+          concatMap (collect isDerivation) (attrValues buildMatrix);
+      };
+
+      platforms = buildMatrix;
+    };
+
   singletonDir = path:
     let
       drv = lib.toDerivation path;


### PR DESCRIPTION
I'm not 100% sure about layout yet (`aggregate` and `platforms.<platform>.<dervation>`), and this is not abstract enough to be applied for repos like `holo-nixpkgs`, but this is momentarily useful for downstream Hydra CI.