### PR TITLE
nixpkgs: restore rust-aarch64-musl-cross.diff

### DIFF
--- a/nixpkgs/rust-aarch64-musl-cross.diff
+++ b/nixpkgs/rust-aarch64-musl-cross.diff
@@ -1,0 +1,15 @@
+diff --git a/pkgs/build-support/rust/default.nix b/pkgs/build-support/rust/default.nix
+index 6afe93c7e4c..94caa912f4c 100644
+--- a/pkgs/build-support/rust/default.nix
++++ b/pkgs/build-support/rust/default.nix
+@@ -86,6 +86,10 @@ in stdenv.mkDerivation (args // {
+     ${stdenv.lib.optionalString (stdenv.buildPlatform.config != stdenv.hostPlatform.config) ''
+     [target."${stdenv.hostPlatform.config}"]
+     "linker" = "${ccForHost}"
++    ${stdenv.lib.optionalString (stdenv.hostPlatform.config == "aarch64-unknown-linux-musl") ''
++    # https://github.com/rust-lang/rust/issues/46651#issuecomment-433611633
++    "rustflags" = [ "-C", "target-feature=+crt-static", "-C", "link-arg=-lgcc" ]
++    ''}
+     ''}
+     EOF
+     cat .cargo/config

--- a/nixpkgs/source.nix
+++ b/nixpkgs/source.nix
@@ -10,6 +10,7 @@ stdenvNoCC.mkDerivation {
 
   patches = [
     ./ext4-no-resize2fs.diff
+    ./rust-aarch64-musl-cross.diff
     ./rust-home.diff
   ];
 


### PR DESCRIPTION
This reapplies 4c2a19f313cd2574f38ae2ea543bc43590619d77.

NixOS 19.09 release doesn't include this patch. We'll only get it once we update to 20.03.