### PR TITLE
nixkpgs/src: bump to c5d5561f772f9ed9de272e3ccb7426de6e862dd1

### DIFF
--- a/nixpkgs/src/default.nix
+++ b/nixpkgs/src/default.nix
@@ -1,7 +1,7 @@
 let
   nixpkgs = fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/5f506b95f9f6290f4c46f523cc3f5cef581c5666.tar.gz";
-    sha256 = "14ry2fs2pny2shlg2dq8c9vns636gv0zvfh0dmyy4bnq713k377n";
+    url = "https://github.com/NixOS/nixpkgs/archive/c5d5561f772f9ed9de272e3ccb7426de6e862dd1.tar.gz";
+    sha256 = "1n41kg3xl2lbwywxpm1bdi37vbrhcww2kg6rl2lwfj9fg7w5sl76";
   };
 
   inherit (import nixpkgs {}) stdenvNoCC fetchpatch;


### PR DESCRIPTION
NixOS/nixpkgs-channels@c5d5561f772f9ed9de272e3ccb7426de6e862dd1 is the latest `nixos-19.09` revision.