### PR TITLE
2020 01 02/hpos admin remove uri

### DIFF
--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -5,6 +5,9 @@ with pkgs;
 let
   holo-router-acme = writeShellScriptBin "holo-router-acme" ''
     base36_id=$(${hpos-config-into-base36-id}/bin/hpos-config-into-base36-id < "$HPOS_CONFIG_PATH")
+    until $(${curl}/bin/curl --fail --head --insecure --output /dev/null --silent "https://$base36_id.holohost.net"); do
+      sleep 5
+    done
     exec ${simp_le}/bin/simp_le \
       --default_root ${config.security.acme.certs.default.webroot} \
       --valid_min ${toString config.security.acme.validMin} \

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -108,7 +108,7 @@ in
         };
 
         "/api/v1/" = {
-          proxyPass = "http://unix:/run/hpos-admin.sock:/";
+          proxyPass = "http://unix:/run/hpos-admin.sock:";
           extraConfig = ''
             auth_request /auth/;
           '';

--- a/profiles/logical/self-aware.nix
+++ b/profiles/logical/self-aware.nix
@@ -17,7 +17,7 @@ in
       ${config.nix.package}/bin/nix ping-store --no-net
 
       if [ ! -e /root/.nix-channels ]; then
-        ${config.nix.package}/bin/nix-channel --add ${config.system.defaultChannel} holo-nixpkgs
+        echo "${config.system.defaultChannel} holo-nixpkgs" > "/root/.nix-channels"
       fi
     ''
   );


### PR DESCRIPTION
If you examine how https://github.com/Holo-Host/holo-nixpkgs/blob/develop/overlays/holo-nixpkgs/hpos-admin-client/hpos-admin-client.py#L43  

hpos-admin-client works it sends requests to `res = request(ctx, 'PUT', '/v1/config' [...]`

removing the trailing slash:

```
diff --git a/profiles/logical/hpos/default.nix b/profiles/logical/hpos/default.nix
index 99ed2e0..d9f4c0a 100644
--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -108,7 +108,7 @@ in
         };
 
         "/api/v1/" = {
-          proxyPass = "http://unix:/run/hpos-admin.sock:/";
+          proxyPass = "http://unix:/run/hpos-admin.sock:";
           extraConfig = ''
             auth_request /auth/;
           '';

```


is the only change needed to be able to pass through requests, which should be formed as seen in the hpos-admin-client example

The nginx docs state

http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass


>  A request URI is passed to the server as follows:
> 
> If the proxy_pass directive is specified with a URI, then when a request is passed to the server, the part of a normalized request URI matching the location is replaced by a URI specified in the directive:
> location /name/ {
>     proxy_pass http://127.0.0.1/remote/;
> }
> If proxy_pass is specified without a URI, the request URI is passed to the server in the same form as sent by a client when the original request is processed, or the full normalized request URI is passed when processing the changed URI:
> location /some/path/ {
>     proxy_pass http://127.0.0.1;
> }
> Before version 1.1.12, if proxy_pass is specified without a URI, the original request URI might be passed instead of the changed URI in some cases.