### PR TITLE
2020 01 08 schema validation

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -49,8 +49,8 @@ let
   hpos-config = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hpos-config";
-    rev = "eb256e2243e08546b078c106541671fb4d4aa61d";
-    sha256 = "0ldbvrda016aha0p55k1nzqb6636micc0x7xf2ffkqn96fz6d6ly";
+    rev = "4cc54e93ae7d61bedd0f6efe813aeff0deb2e633";
+    sha256 = "15z81xzzyf9ca6wdmn8dzkv6zh6nvz53v1xyhzs4g4gk7dbiw1i7";
   };
 
   nixpkgs-mozilla = fetchTarball {
@@ -94,6 +94,7 @@ in
     hpos-config-gen-cli
     hpos-config-into-base36-id
     hpos-config-into-keystore
+    hpos-config-py
     ;
 
   inherit (callPackage npm-to-nix {}) npmToNix;
@@ -216,11 +217,7 @@ in
     };
   };
 
-  hpos-admin = callPackage ./hpos-admin {
-    stdenv = stdenvNoCC;
-    python3 = python3.withPackages (ps: [ ps.flask ps.gevent ]);
-  };
-
+  hpos-admin = python3Packages.callPackage ./hpos-admin {};
   hpos-admin-client = callPackage ./hpos-admin-client {
     stdenv = stdenvNoCC;
     python3 = python3.withPackages (ps: [ ps.click ps.requests ]);

--- a/overlays/holo-nixpkgs/hpos-admin/default.nix
+++ b/overlays/holo-nixpkgs/hpos-admin/default.nix
@@ -1,17 +1,23 @@
-{ stdenv, makeWrapper, python3 }:
+{ buildPythonApplication
+, python3Packages
+, gitignoreSource
+, hpos-config-py
+}:
 
-with stdenv.lib;
+with python3Packages;
 
-stdenv.mkDerivation rec {
+buildPythonApplication {
   name = "hpos-admin";
+  src = gitignoreSource ./.;
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ python3 ];
+  propagatedBuildInputs = [
+    flask
+    gevent
+    hpos-config-py
+  ];
 
-  buildCommand = ''
-    makeWrapper ${python3}/bin/python3 $out/bin/${name} \
-      --add-flags ${./hpos-admin.py} 
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    python3 -m pytest
   '';
-
-  meta.platforms = platforms.linux;
 }

--- a/overlays/holo-nixpkgs/hpos-admin/hpos_admin/main.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos_admin/main.py
@@ -44,6 +44,11 @@ def cas_hash(data):
     return b64_hash(json.dumps(data, separators=(',', ':'), sort_keys=True))
 
 
+@app.route('/api/v1/config_cas', methods=['GET'])
+def get_settings_cas():
+    return jsonify(cas_hash(get_state_data()['v1']['settings']))
+
+
 @app.route('/api/v1/config', methods=['GET'])
 def get_settings():
     settings = get_state_data()['v1']['settings']

--- a/overlays/holo-nixpkgs/hpos-admin/hpos_admin/main.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos_admin/main.py
@@ -6,6 +6,7 @@ from tempfile import mkstemp
 import json
 import logging
 import os
+import stat
 
 from hpos_config.schema import check_config
 
@@ -43,12 +44,12 @@ def cas_hash(data):
     return b64_hash(json.dumps(data, separators=(',', ':'), sort_keys=True))
 
 
-@app.route('/v1/config', methods=['GET'])
+@app.route('/api/v1/config', methods=['GET'])
 def get_settings_cas():
     return jsonify(cas_hash(get_state_data()['v1']['settings']))
 
 
-@app.route('/v1/config', methods=['GET'])
+@app.route('/api/v1/config', methods=['GET'])
 def get_settings():
     settings = get_state_data()['v1']['settings']
     settings_cas = cas_hash(settings)
@@ -79,7 +80,7 @@ def update_settings(cas, config, settings):
     return config
 
 
-@app.route('/v1/config', methods=['PUT'])
+@app.route('/api/v1/config', methods=['PUT'])
 def put_settings():
     try:
         verify_body_hash(request)
@@ -121,6 +122,7 @@ def unix_socket(path):
         os.remove(path)
     sock.bind(path)
     sock.listen()
+    os.chmod(path, stat.S_IRWXU|stat.S_IRWXG|stat.S_IRWXO) # support various services' users connecting
     return sock
 
 

--- a/overlays/holo-nixpkgs/hpos-admin/hpos_admin/main.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos_admin/main.py
@@ -45,15 +45,9 @@ def cas_hash(data):
 
 
 @app.route('/api/v1/config', methods=['GET'])
-def get_settings_cas():
-    return jsonify(cas_hash(get_state_data()['v1']['settings']))
-
-
-@app.route('/api/v1/config', methods=['GET'])
 def get_settings():
     settings = get_state_data()['v1']['settings']
-    settings_cas = cas_hash(settings)
-    return jsonify(settings), 200, { 'x-hpos-admin-cas': settings_cas }
+    return jsonify(settings), 200, { 'x-hpos-admin-cas': cas_hash(settings) }
 
 
 def replace_file_contents(path, data):

--- a/overlays/holo-nixpkgs/hpos-admin/hpos_admin/main_test.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos_admin/main_test.py
@@ -4,15 +4,17 @@ import json
 from hpos_admin.main import cas_hash, update_settings
 from hpos_config.schema_test import config_json
 
-config = json.loads(config_json)
-config_cas = cas_hash(config['v1']['settings'])
+config_cas = cas_hash(json.loads(config_json)['v1']['settings'])
 
 def test_cas():
     assert config_cas == "KkrCSBphJighnRPEnJE9FmM8DiGKW4Jc5L9DjJ1KNroZ8ySt/Aw+BptpGimd78navA+7NUhoA9U/Z4Tsh/m4Lw=="
 
 def test_schema():
     settings = { 'admin': { 'email': "a@b.ca", 'public_key': 'xyz==' }}
+    settings_bad = { 'admin': { 'email': "a<at>b.ca", 'public_key': 'xyz==' }}
     with pytest.raises(AssertionError, match='.*x-hpos-admin-cas header did not match.*') as exc_info:
-        update_settings(cas="abc==", config=config, settings=settings)
-    config_updated = update_settings(cas=config_cas, config=config, settings=settings)
+        update_settings(cas="abc==", config=json.loads(config_json), settings=settings)
+    config_updated = update_settings(cas=config_cas, config=json.loads(config_json), settings=settings)
     assert config_updated['v1']['settings'] == settings
+    with pytest.raises(AssertionError, match='.*Expected.*email to satisfy predicate is_email.*') as exc_info:
+        update_settings(cas=config_cas, config=json.loads(config_json), settings=settings_bad)

--- a/overlays/holo-nixpkgs/hpos-admin/hpos_admin/main_test.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos_admin/main_test.py
@@ -1,0 +1,18 @@
+import pytest
+import json
+
+from hpos_admin.main import cas_hash, update_settings
+from hpos_config.schema_test import config_json
+
+config = json.loads(config_json)
+config_cas = cas_hash(config['v1']['settings'])
+
+def test_cas():
+    assert config_cas == "KkrCSBphJighnRPEnJE9FmM8DiGKW4Jc5L9DjJ1KNroZ8ySt/Aw+BptpGimd78navA+7NUhoA9U/Z4Tsh/m4Lw=="
+
+def test_schema():
+    settings = { 'admin': { 'email': "a@b.ca", 'public_key': 'xyz==' }}
+    with pytest.raises(AssertionError, match='.*x-hpos-admin-cas header did not match.*') as exc_info:
+        update_settings(cas="abc==", config=config, settings=settings)
+    config_updated = update_settings(cas=config_cas, config=config, settings=settings)
+    assert config_updated['v1']['settings'] == settings

--- a/overlays/holo-nixpkgs/hpos-admin/setup.py
+++ b/overlays/holo-nixpkgs/hpos-admin/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name='hpos-admin',
+    packages=['hpos_admin'],
+    entry_points={
+        'console_scripts': [
+            'hpos-admin=hpos_admin.main:main'
+        ],
+    },
+    install_requires=['hpos-config']
+)

--- a/overlays/holo-nixpkgs/hpos-init/default.nix
+++ b/overlays/holo-nixpkgs/hpos-init/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , gitignoreSource
 , magic-wormhole
+, hpos-config-py
 }:
 
 let
@@ -24,6 +25,8 @@ in
 buildPythonApplication {
   name = "hpos-init";
   src = gitignoreSource ./.;
-
-  propagatedBuildInputs = [ hpos-seed ];
+  propagatedBuildInputs = [
+    hpos-seed
+    hpos-config-py
+  ];
 }

--- a/overlays/holo-nixpkgs/hpos-init/setup.py
+++ b/overlays/holo-nixpkgs/hpos-init/setup.py
@@ -8,5 +8,5 @@ setup(
             'hpos-init=hpos_init.main:main'
         ],
     },
-    install_requires=['hpos-seed']
+    install_requires=['hpos-seed', 'hpos-config']
 )


### PR DESCRIPTION
Runs hpos-shell w/ hpos-init and hpos-admin using hpos_config schema
 - Tested by uploading various faulty hpos-config.json files on init
 - Don't merge 'til we use the HPOS Admin UI to test hpos-admin settings

Does *not* test hpos-config.json schema inside hpos-seed server-side implementation code, because it is necessary to change the wormhole protocol flow to do it, and I couldn't determine how to accomplish this.  So, in the mean time, it uses the standard "holo-init wormhole failed" procedure, and issues a new wormhole code w/ associated exponential back-off, on schema failure during holo init.

This can be done quite easily as a future improvement.  In the mean time, both hpos-init and hpos-admin conduits to breaking the hpos-config.json file have been addressed by this pull request.