### PR TITLE
Update DNAs to use sharded sim2h servers

### DIFF
--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -19,8 +19,8 @@ let
   holo-hosting-app = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-hosting-app";
-    rev = "30b329c1ee0e4354c8ef05b8651144f01797cc17";
-    sha256 = "187w7b1gj52iypf283n10cbnd9731r0xy3bq2v8qfhdrrwp6gnb3";
+    rev = "12e57f7133c376f1bdbcb5c63135e99fbeabe771";
+    sha256 = "18isckq31j30s0krmmhb3m75dip0rqfxnp3f4000mfni0si1jwjj";
   };
 
   holo-communities-dna = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -33,8 +33,8 @@ let
   servicelogger = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "servicelogger";
-    rev = "d4b411bc969e2c56436fb6c3ae5c2a2a62d26a17";
-    sha256 = "0i5a8757sikgcsrf5ppi9lbnisi5iqxh0rphkpqrd52ibpf6nfsz";
+    rev = "a464f862e757c40b8d4eadc48a7afa95c6092691";
+    sha256 = "0a2sq04jrwndpjn4fccjz4hwajfskx9jbhy974hxnm9klz01sc5r";
   };
 in
 

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -6,8 +6,8 @@ let
   happ-store = fetchFromGitHub {
     owner = "holochain";
     repo = "happ-store";
-    rev = "f9c5bb938376780b7e41d3234ff21baa6e04fb59";
-    sha256 = "174nhbbxcajdz8z27fhgs7r1py2ap69i8mkam2bn4pvh4skgabl4";
+    rev = "04877c9b9219152685c20c4b5a79913c5f36f1a4";
+    sha256 = "1xk1727ddwck36sa26rbmib1gyzdf4055wav3h52qafz8jqzikdn";
   };
 
   holofuel = fetchurl {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -11,9 +11,9 @@ let
   };
 
   holofuel = fetchurl {
-    url = "https://holo-host.github.io/holofuel/releases/download/v0.14.4-alpha1/holofuel.dna.json";
+    url = "https://holo-host.github.io/holofuel/releases/download/v0.15.0-alpha1/holofuel.dna.json";
     name = "holofuel.dna.json";
-    sha256 = "1bzrmw3v0kf6q76s6h56cyxv5axjcjd0axpkbkp07y7cdd8s356r";
+    sha256 = "0x69z713yy99z53mwfkpy2wg1l58csxrh9fgiqa7vhqvghwgiym7";
   };
 
   holo-hosting-app = fetchFromGitHub {

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -155,7 +155,7 @@ in
       instances = map instanceConfig dnas;
       network = {
         type = "sim2h";
-        sim2h_url = "wss://sim2h.holochain.org:9000";
+        sim2h_url = "ws://public.sim2h.net:9000";
       };
       persistence_dir = conductorHome;
       signing_service_uri = "http://localhost:9676";


### PR DESCRIPTION
Updated pointers for:
- happ-store
- holo-hosting-app
- servicelogger 
- holofuel

### Reason for update:
Updated all DNAs to use a default sim2h server for specified DNA.