### PR TITLE
Patch nginx to include wasm mime type

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -267,6 +267,10 @@ in
 
   magic-wormhole-mailbox-server = python3Packages.callPackage ./magic-wormhole-mailbox-server {};
 
+  nginx = previous.nginx.overrideAttrs (super: {
+    patches = super.patches ++ [ ./nginx/add-wasm-mime-type.patch ];
+  });
+
   nodejs = nodejs-12_x;
 
   rust = previous.rust // {

--- a/overlays/holo-nixpkgs/nginx/add-wasm-mime-type.patch
+++ b/overlays/holo-nixpkgs/nginx/add-wasm-mime-type.patch
@@ -1,0 +1,24 @@
+From 8df72fb9a914e5a3469685ec6633e24509eedb05 Mon Sep 17 00:00:00 2001
+From: PJ <pj@imagine-nyc.com>
+Date: Mon, 10 Feb 2020 10:11:41 +0100
+Subject: [PATCH] conf: add application/wasm mime type
+
+---
+ conf/mime.types | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/conf/mime.types b/conf/mime.types
+index 2961256..b53f7f7 100644
+--- a/conf/mime.types
++++ b/conf/mime.types
+@@ -51,6 +51,7 @@ types {
+     application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                      docx;
+     application/vnd.wap.wmlc                         wmlc;
++    application/wasm                                 wasm;
+     application/x-7z-compressed                      7z;
+     application/x-cocoa                              cco;
+     application/x-java-archive-diff                  jardiff;
+-- 
+2.7.1
+


### PR DESCRIPTION
Original `mime.types` file in nginx does not contain an entry for application/wasm. Instead of passing `extraConfig` to nginx.conf I have patched nginx `mime.types` file. 