### PR TITLE
Add DNA hash to instance storage path

### DIFF
--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -41,7 +41,7 @@ let
     dna = drv.name;
     id = drv.name;
     storage = {
-      path = "${conductorHome}/${drv.name}";
+      path = "${conductorHome}/${drv.name}-${pkgs.dnaHash drv}";
       type = "file";
     };
   };


### PR DESCRIPTION
This resolves an issue where each change of DNA in conductor configuration was resulting in corrupted local DHT storage.