### PR TITLE
.github/settings.yml: allow Central and hAppy teams commit access

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -16,6 +16,8 @@ collaborators: []
 teams:
   - name: central
     permission: push
+  - name: happy
+    permission: push
   - name: hydra
     permission: push
 


### PR DESCRIPTION
This allows anyone in Central and hAppy teams write and `develop` commit access to this repo.

cc @Holo-Host/central @Holo-Host/happy