### PR TITLE
holochain-rust: version bump to v0.0.43-alpha3 / dnaPackages: all dnas version bumps

### DIFF
--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -32,11 +32,11 @@ let
 in
 
 {
-  inherit (callPackage happ-store {}) happ-store;
+  # inherit (callPackage happ-store {}) happ-store;
 
-  inherit (callPackage holo-hosting-app {}) holo-hosting-app;
+  # inherit (callPackage holo-hosting-app {}) holo-hosting-app;
 
-  inherit (callPackage servicelogger {}) servicelogger;
+  # inherit (callPackage servicelogger {}) servicelogger;
 
   holofuel = wrapDNA holofuel;
 }

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -26,8 +26,8 @@ let
   servicelogger = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "servicelogger";
-    rev = "d4b411bc969e2c56436fb6c3ae5c2a2a62d26a17";
-    sha256 = "0i5a8757sikgcsrf5ppi9lbnisi5iqxh0rphkpqrd52ibpf6nfsz";
+    rev = "7f14de64f760946cbe54822a8ba35ccdc8e56a5d";
+    sha256 = "1l7lwg2h373lvi51vfcbin5wjfmvxl01smnb420vsh8g00mb6aq2";
   };
 in
 
@@ -36,7 +36,7 @@ in
 
   inherit (callPackage holo-hosting-app {}) holo-hosting-app;
 
-  # inherit (callPackage servicelogger {}) servicelogger;
+  inherit (callPackage servicelogger {}) servicelogger;
 
   holofuel = wrapDNA holofuel;
 }

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -11,9 +11,9 @@ let
   };
 
   holofuel = fetchurl {
-    url = "https://github.com/zo-el/temp/releases/download/0.0.1/holofuel.dna.json";
+    url = "https://holo-host.github.io/holofuel/releases/download/v0.16.0-alpha1/holofuel.dna.json";
     name = "holofuel.dna.json";
-    sha256 = "0pbcrpwf9q2kki4hcdiz8xxv9w2swadvjm5pjjfp59g81k212wrl";
+    sha256 = "00262l6p5xlv1c2ypj5sjzpkc42qn883nhkwxv05hrj11af22zdh";
   };
 
   holo-hosting-app = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -6,21 +6,21 @@ let
   happ-store = fetchFromGitHub {
     owner = "holochain";
     repo = "happ-store";
-    rev = "f9c5bb938376780b7e41d3234ff21baa6e04fb59";
-    sha256 = "174nhbbxcajdz8z27fhgs7r1py2ap69i8mkam2bn4pvh4skgabl4";
+    rev = "d775015e6a983b6d5b75a93ba9915516d65613b4";
+    sha256 = "1c4iblk0bqmrj7l63aaxgc3spxk0vl7ix9w1gnp5izgwiqas22il";
   };
 
   holofuel = fetchurl {
-    url = "https://holo-host.github.io/holofuel/releases/download/v0.14.4-alpha1/holofuel.dna.json";
+    url = "https://holo-host.github.io/holofuel/releases/download/v0.16.0-alpha1/holofuel.dna.json";
     name = "holofuel.dna.json";
-    sha256 = "1bzrmw3v0kf6q76s6h56cyxv5axjcjd0axpkbkp07y7cdd8s356r";
+    sha256 = "00262l6p5xlv1c2ypj5sjzpkc42qn883nhkwxv05hrj11af22zdh";
   };
 
   holo-hosting-app = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-hosting-app";
-    rev = "30b329c1ee0e4354c8ef05b8651144f01797cc17";
-    sha256 = "187w7b1gj52iypf283n10cbnd9731r0xy3bq2v8qfhdrrwp6gnb3";
+    rev = "80996df0ae38ba623c850d8399fc9e2412db6bb0";
+    sha256 = "1w6lgi50a6sagcpyfmyw1d61kdvd569rihrmf5a105yj9kq3xg4l";
   };
 
   servicelogger = fetchFromGitHub {
@@ -32,9 +32,9 @@ let
 in
 
 {
-  # inherit (callPackage happ-store {}) happ-store;
+  inherit (callPackage happ-store {}) happ-store;
 
-  # inherit (callPackage holo-hosting-app {}) holo-hosting-app;
+  inherit (callPackage holo-hosting-app {}) holo-hosting-app;
 
   # inherit (callPackage servicelogger {}) servicelogger;
 

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -11,9 +11,9 @@ let
   };
 
   holofuel = fetchurl {
-    url = "https://holo-host.github.io/holofuel/releases/download/v0.16.0-alpha1/holofuel.dna.json";
+    url = "https://github.com/zo-el/temp/releases/download/0.0.1/holofuel.dna.json";
     name = "holofuel.dna.json";
-    sha256 = "00262l6p5xlv1c2ypj5sjzpkc42qn883nhkwxv05hrj11af22zdh";
+    sha256 = "0pbcrpwf9q2kki4hcdiz8xxv9w2swadvjm5pjjfp59g81k212wrl";
   };
 
   holo-hosting-app = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/holochain-rust/default.nix
+++ b/overlays/holo-nixpkgs/holochain-rust/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, rustPlatform, fetchFromGitHub, perl, CoreServices, Security, libsodium }:
+{ stdenv, rustPlatform, fetchFromGitHub, perl, CoreServices, Security, libsodium, pcre }:
 
 rustPlatform.buildRustPackage {
   name = "holochain-rust";
@@ -10,9 +10,14 @@ rustPlatform.buildRustPackage {
     sha256 = "01gd19f2xspi07gbnvb3hjlhwrhf6yjhapikrayi4jvp2w603y6g";
   };
 
-  cargoSha256 = "1cfk2z4pbk8dli31wpplczd8a1fy8fyhwa5rsl6yz3jzw9d2kdkk";
+  cargoSha256 = "00fjzzvaiyawds27g4fvwsnq7gcgadam26p07zq11hz0c1dw5krd";
 
-  nativeBuildInputs = [ perl ];
+  # needed for newrelic to compile its dependencies
+  # this is a hack to workaround this:
+  # https://github.com/NixOS/nixpkgs/issues/18995
+  hardeningDisable = [ "fortify" ];
+
+  nativeBuildInputs = [ perl pcre ];
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [
     CoreServices

--- a/overlays/holo-nixpkgs/holochain-rust/default.nix
+++ b/overlays/holo-nixpkgs/holochain-rust/default.nix
@@ -6,8 +6,8 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "holochain-rust";
-    rev = "v0.0.42-alpha5";
-    sha256 = "0x1vnhyq6ksjk2ci7c5kw6n1l8dwfz940sd4vzrcmzl7hhwvpd45";
+    rev = "1481cc930c5c6fdeccb3674efbaed20d135adfeb";
+    sha256 = "01gd19f2xspi07gbnvb3hjlhwrhf6yjhapikrayi4jvp2w603y6g";
   };
 
   cargoSha256 = "1cfk2z4pbk8dli31wpplczd8a1fy8fyhwa5rsl6yz3jzw9d2kdkk";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -162,7 +162,7 @@ in
       instances = map instanceConfig dnas;
       network = {
         type = "sim2h";
-        sim2h_url = "ws://sim2h-test.holo.host:9001";
+        sim2h_url = "ws://sim2h-test.holo.host:9003";
       };
       persistence_dir = conductorHome;
       signing_service_uri = "http://localhost:9676";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -165,7 +165,7 @@ in
       instances = map instanceConfig dnas;
       network = {
         type = "sim2h";
-        sim2h_url = "ws://hosting.sim2h.net:9000";
+        sim2h_url = "ws://hpos-2.holo.host:9000";
       };
       persistence_dir = conductorHome;
       signing_service_uri = "http://localhost:9676";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -165,7 +165,7 @@ in
       instances = map instanceConfig dnas;
       network = {
         type = "sim2h";
-        sim2h_url = "ws://sim2h-test.holo.host:9001 ";
+        sim2h_url = "ws://sim2h-test.holo.host:9001";
       };
       persistence_dir = conductorHome;
       signing_service_uri = "http://localhost:9676";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -23,10 +23,7 @@ let
   conductorHome = "/var/lib/holochain-conductor";
 
   dnas = with dnaPackages; [
-    happ-store
-    holo-hosting-app
     holofuel
-    servicelogger
   ];
 
   dnaConfig = drv: {

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -165,7 +165,7 @@ in
       instances = map instanceConfig dnas;
       network = {
         type = "sim2h";
-        sim2h_url = "ws://hpos-2.holo.host:9000";
+        sim2h_url = "ws://sim2h-test.holo.host:9001 ";
       };
       persistence_dir = conductorHome;
       signing_service_uri = "http://localhost:9676";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -162,7 +162,7 @@ in
       instances = map instanceConfig dnas;
       network = {
         type = "sim2h";
-        sim2h_url = "ws://sim2h-test.holo.host:9003";
+        sim2h_url = "ws://sim2h-test.holo.host:9001";
       };
       persistence_dir = conductorHome;
       signing_service_uri = "http://localhost:9676";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -165,7 +165,7 @@ in
       instances = map instanceConfig dnas;
       network = {
         type = "sim2h";
-        sim2h_url = "ws://public.sim2h.net:9000";
+        sim2h_url = "ws://hosting.sim2h.net:9000";
       };
       persistence_dir = conductorHome;
       signing_service_uri = "http://localhost:9676";

--- a/release.nix
+++ b/release.nix
@@ -15,8 +15,6 @@ in
   with import "${pkgs.path}/pkgs/top-level/release-lib.nix" {
     nixpkgsArgs.overlays = [ overlay ];
     supportedSystems = [
-      "aarch64-linux"
-      "x86_64-darwin"
       "x86_64-linux"
     ];
   };


### PR DESCRIPTION
This branch started of as a test branch. But now needs to be reviewed because it is the closest branch that runs hp-admin and the DNA's successfully (Tested out by the QA team).

## Updates:
- Holochain-rust version bumped to 0.0.43-alpha3 
- holo-hosting-app, happ-store, servicelogger and holofuel dnaPackages version bumped 
 