### PR TITLE
holochain-rust: version bump to v0.0.45-alpha1

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -42,8 +42,8 @@ let
   hp-admin = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hp-admin";
-    rev = "0.10.0";
-    sha256 = "1ns504fqz79dym6f88502qyhfrzy1y73qz17wsvihj13mbcnbndk";
+    rev = "995c2ec11283d26f87fc1a9307f754271719bfb8";
+    sha256 = "0gyrvrqbzgfb87skd2bv55jrmr9wz33ba82wq6flg967qrk1xx8i";
   };
 
   hp-admin-crypto = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -11,9 +11,9 @@ let
   };
 
   holofuel = fetchurl {
-    url = "https://holo-host.github.io/holofuel/releases/download/v0.14.4-alpha1/holofuel.dna.json";
+    url = "https://holo-host.github.io/holofuel/releases/download/v0.18.0-alpha1/holofuel.dna.json";
     name = "holofuel.dna.json";
-    sha256 = "1bzrmw3v0kf6q76s6h56cyxv5axjcjd0axpkbkp07y7cdd8s356r";
+    sha256 = "1vz2qbr3ayb42l0cjyxmhrkab3qzzm0aln7ibgsqk57pw6ra0rgr";
   };
 
   holo-hosting-app = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -6,8 +6,8 @@ let
   happ-store = fetchFromGitHub {
     owner = "holochain";
     repo = "happ-store";
-    rev = "f9c5bb938376780b7e41d3234ff21baa6e04fb59";
-    sha256 = "174nhbbxcajdz8z27fhgs7r1py2ap69i8mkam2bn4pvh4skgabl4";
+    rev = "a7feb1f701753da2b0b3c1de9d6bc1c13896782b";
+    sha256 = "17d94cwk4xgf6i2xx50bxyk1bq68dc1ps4hi9wjy7f1c2qclgfdy";
   };
 
   holofuel = fetchurl {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -26,8 +26,8 @@ let
   servicelogger = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "servicelogger";
-    rev = "d4b411bc969e2c56436fb6c3ae5c2a2a62d26a17";
-    sha256 = "0i5a8757sikgcsrf5ppi9lbnisi5iqxh0rphkpqrd52ibpf6nfsz";
+    rev = "33fa8304ea00284b73f454d05d61817db53e2869";
+    sha256 = "0b5whd5hgh7zdgf9ppw7z4691ypw5qqim7cv1nx1hqhiyxy8cimh";
   };
 in
 

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -19,8 +19,8 @@ let
   holo-hosting-app = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-hosting-app";
-    rev = "30b329c1ee0e4354c8ef05b8651144f01797cc17";
-    sha256 = "187w7b1gj52iypf283n10cbnd9731r0xy3bq2v8qfhdrrwp6gnb3";
+    rev = "37013a19c4f2546304e2abea6951e2e06863fcbc";
+    sha256 = "1i43k1wwcpmvx60db2kvbsvfihkfy2nn6iqqwcxz00gqm6pihr2q";
   };
 
   servicelogger = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/holochain-rust/default.nix
+++ b/overlays/holo-nixpkgs/holochain-rust/default.nix
@@ -6,11 +6,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "holochain-rust";
-    rev = "v0.0.42-alpha5";
-    sha256 = "0x1vnhyq6ksjk2ci7c5kw6n1l8dwfz940sd4vzrcmzl7hhwvpd45";
+    rev = "3a88ae4977162b4310aae4dcef1673844ec76d84";
+    sha256 = "1j0ml6bim93xp57vm3d3mfd6hig6j7i8pj7flvarbalvv0gdn46c";
   };
 
-  cargoSha256 = "1cfk2z4pbk8dli31wpplczd8a1fy8fyhwa5rsl6yz3jzw9d2kdkk";
+  cargoSha256 = "17aajvvk2bcy4qkb4n7r8fmvpd9ab7aww0yndwwdgvi9mi5ilwy8";
 
   nativeBuildInputs = [ perl ];
 


### PR DESCRIPTION
Bumps version of holochain-rust to v0.0.45-alpha1, also bumps all DNAs to a compatible version