### PR TITLE
Test: limit holochain logging to info without state_dumps

### DIFF
--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -167,6 +167,10 @@ in
         type = "sim2h";
         sim2h_url = "ws://public.sim2h.net:9000";
       };
+      logger = {
+        state_dump = false;
+        type = "info";
+      }
       persistence_dir = conductorHome;
       signing_service_uri = "http://localhost:9676";
       interfaces = [


### PR DESCRIPTION
I noticed several of the holochain log errors are things we probably don't want to see in journalctl logs (e.g. `Aspect already being held`) so I'm trying `type = "info"` in this PR.