### PR TITLE
holochain-rust: bump to a56c2a7bdb6a12e6f574f6e6510634c7099282aa

### DIFF
--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -26,8 +26,8 @@ let
   servicelogger = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "servicelogger";
-    rev = "d4b411bc969e2c56436fb6c3ae5c2a2a62d26a17";
-    sha256 = "0i5a8757sikgcsrf5ppi9lbnisi5iqxh0rphkpqrd52ibpf6nfsz";
+    rev = "c441986f020a27e791b034ab19a69536565cd9e9";
+    sha256 = "06yznsj76fzz1yqxi6rs0ihqhyrz9kvngasyrlkhwm44mg1693nh";
   };
 in
 

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -6,8 +6,8 @@ let
   happ-store = fetchFromGitHub {
     owner = "holochain";
     repo = "happ-store";
-    rev = "f9c5bb938376780b7e41d3234ff21baa6e04fb59";
-    sha256 = "174nhbbxcajdz8z27fhgs7r1py2ap69i8mkam2bn4pvh4skgabl4";
+    rev = "3c13dd7015f58f5246dc066582179f64d510a243";
+    sha256 = "0m4d6bcg5cdiqriqj4xmfjv389kimfj02292iibm3zpbq1n7hfls";
   };
 
   holofuel = fetchurl {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -19,8 +19,8 @@ let
   holo-hosting-app = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-hosting-app";
-    rev = "30b329c1ee0e4354c8ef05b8651144f01797cc17";
-    sha256 = "187w7b1gj52iypf283n10cbnd9731r0xy3bq2v8qfhdrrwp6gnb3";
+    rev = "389c510181fbb4e93fb8c11d2c6ce5e30602136a";
+    sha256 = "0ana7v380k010np7h029fyxmfkk5k30b50ka3g0zda3z56582ziz";
   };
 
   servicelogger = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -11,9 +11,9 @@ let
   };
 
   holofuel = fetchurl {
-    url = "https://holo-host.github.io/holofuel/releases/download/v0.14.4-alpha1/holofuel.dna.json";
+    url = "https://holo-host.github.io/holofuel/releases/download/v0.16.0-alpha2/holofuel.dna.json";
     name = "holofuel.dna.json";
-    sha256 = "1bzrmw3v0kf6q76s6h56cyxv5axjcjd0axpkbkp07y7cdd8s356r";
+    sha256 = "1pwz9wd0wwg4dj361b3mvmpwp74bgq29z7c5913na8iy87i2mn6s";
   };
 
   holo-hosting-app = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/holochain-rust/default.nix
+++ b/overlays/holo-nixpkgs/holochain-rust/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, rustPlatform, fetchFromGitHub, perl, CoreServices, Security, libsodium }:
+{ stdenv, rustPlatform, fetchFromGitHub, pcre, perl, CoreServices, Security, libsodium }:
 
 rustPlatform.buildRustPackage {
   name = "holochain-rust";
@@ -6,13 +6,13 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "holochain-rust";
-    rev = "v0.0.44-alpha3";
-    sha256 = "18c6y1x7jx5brzghh9q7yfml88sah02x0cshmjzxxb0qy0n52zrl";
+    rev = "a56c2a7bdb6a12e6f574f6e6510634c7099282aa";
+    sha256 = "1ab789hppfi2asjpdkvg2nfndcx27v8yvs1lpnvpngqvk9pnb4gg";
   };
 
-  cargoSha256 = "1r4wb24bgjbhcg9cnlpwr0hva2f153wm2iyl7lmf89bvyx7qalic";
+  cargoSha256 = "16w403az65fi2dyf0g5j7w5rkmfkx318d5dwx4jgq43fgqrxfhfy";
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ pcre perl ];
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [
     CoreServices

--- a/overlays/holo-nixpkgs/holochain-rust/default.nix
+++ b/overlays/holo-nixpkgs/holochain-rust/default.nix
@@ -6,11 +6,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "holochain-rust";
-    rev = "v0.0.42-alpha5";
-    sha256 = "0x1vnhyq6ksjk2ci7c5kw6n1l8dwfz940sd4vzrcmzl7hhwvpd45";
+    rev = "v0.0.44-alpha3";
+    sha256 = "18c6y1x7jx5brzghh9q7yfml88sah02x0cshmjzxxb0qy0n52zrl";
   };
 
-  cargoSha256 = "1cfk2z4pbk8dli31wpplczd8a1fy8fyhwa5rsl6yz3jzw9d2kdkk";
+  cargoSha256 = "1r4wb24bgjbhcg9cnlpwr0hva2f153wm2iyl7lmf89bvyx7qalic";
 
   nativeBuildInputs = [ perl ];
 


### PR DESCRIPTION
This is an alternative to #403 that follows `holochain-rust` `remove-newrelic` branch.

cc @peeech @zo-el 