### PR TITLE
add staging profile with ssh access open

### DIFF
--- a/profiles/logical/hpos/staged/default.nix
+++ b/profiles/logical/hpos/staged/default.nix
@@ -5,6 +5,8 @@ with pkgs;
 {
   imports = [ ../. ];
 
+  services.openssh.enable = true;
+
   users.users.root.openssh.authorizedKeys.keys = lib.mkForce [
     # Matthew Brisebois
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGakK6G+lvSpg3NKfuWNopUlI/Z2keLGBH09jeAVbslO"


### PR DESCRIPTION
Enables ssh daemon. That way Hosts can elect to grant access to their HoloPorts to the holders of ssh keys listed in `holo-nixpkgs/profiles/logical/hpos/staged`, by simply updating the config file `/etc/nixos/configuration.nix` on their machine in the following way:
```
{
  imports = [
    <holo-nixpkgs/profiles/targets/holoport-plus>
+    <holo-nixpkgs/profiles/logical/hpos/staged>
    ./hardware-configuration.nix
  ];

...
}
```
Closes #404 