### PR TITLE
services.holochain-conductor: make conductor config permanent

### DIFF
--- a/modules/services/holochain-conductor.nix
+++ b/modules/services/holochain-conductor.nix
@@ -28,10 +28,12 @@ in
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        ${pkgs.hpos-config-into-keystore}/bin/hpos-config-into-keystore \
-          < $HPOS_CONFIG_PATH > /tmp/holo-keystore 2> /tmp/holo-keystore.pub
-        export HOLO_KEYSTORE_HCID=$(cat /tmp/holo-keystore.pub)
-        ${pkgs.envsubst}/bin/envsubst < ${pkgs.writeTOML cfg.config} > $STATE_DIRECTORY/conductor-config.toml
+      if [ ! -f $STATE_DIRECTORY/conductor-config.toml ]; then
+          ${pkgs.hpos-config-into-keystore}/bin/hpos-config-into-keystore \
+            < $HPOS_CONFIG_PATH > /tmp/holo-keystore 2> /tmp/holo-keystore.pub
+          export HOLO_KEYSTORE_HCID=$(cat /tmp/holo-keystore.pub)
+          ${pkgs.envsubst}/bin/envsubst < ${pkgs.writeTOML cfg.config} > $STATE_DIRECTORY/conductor-config.toml
+      fi
       '';
 
       serviceConfig = {


### PR DESCRIPTION
Checking if the holochain-conductor state file exists on service start, so we do not overwrite it on each start, given the conductor writes to it. ```hpos-reset``` will take care of removing it if needed.