### PR TITLE
Create keystore unconditionally

### DIFF
--- a/modules/services/holochain-conductor.nix
+++ b/modules/services/holochain-conductor.nix
@@ -28,10 +28,10 @@ in
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
+      ${pkgs.hpos-config-into-keystore}/bin/hpos-config-into-keystore \
+        < $HPOS_CONFIG_PATH > /tmp/holo-keystore 2> /tmp/holo-keystore.pub
+      export HOLO_KEYSTORE_HCID=$(cat /tmp/holo-keystore.pub)
       if [ ! -f $STATE_DIRECTORY/conductor-config.toml ]; then
-          ${pkgs.hpos-config-into-keystore}/bin/hpos-config-into-keystore \
-            < $HPOS_CONFIG_PATH > /tmp/holo-keystore 2> /tmp/holo-keystore.pub
-          export HOLO_KEYSTORE_HCID=$(cat /tmp/holo-keystore.pub)
           ${pkgs.envsubst}/bin/envsubst < ${pkgs.writeTOML cfg.config} > $STATE_DIRECTORY/conductor-config.toml
       fi
       '';


### PR DESCRIPTION
Fixes an issue where holochain keystore is not created on conductor start-up