### PR TITLE
usb-reset: implement via devmon

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ https://hydra.holo.host/job/holo-nixpkgs/master/holoportos.targets.virtualbox.x8
 Refer to [VirtualBox manual, chapter 1, section 1.15.2](https://www.virtualbox.org/manual/ch01.html#ovf-import-appliance).
 
 [nix]: https://nixos.org/nix/
+<!-- :) -->

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -16,6 +16,7 @@
     ./services/magic-wormhole-mailbox-server.nix
     ./services/sim2h-server.nix
     ./system/holo-nixpkgs/auto-upgrade.nix
+    ./system/holo-nixpkgs/usb-reset.nix
   ];
 
   # Compat shim, to be removed along with /profiles/targets:

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./services/aorura-emu.nix
+    ./services/automount.nix
     ./services/dnscrypt-proxy2.nix
     ./services/holo-auth-client.nix
     ./services/holo-router-agent.nix

--- a/modules/services/automount.nix
+++ b/modules/services/automount.nix
@@ -1,0 +1,44 @@
+{ pkgs, config, lib, ... }:
+
+with lib;
+
+let cfg = config.services.automount;
+
+in {
+  disabledModules = [ "services/misc/devmon.nix" ];
+
+  options = {
+    services.automount = {
+      enable = mkEnableOption "automatic mounting of drives via devmon";
+
+      execOnDrive = mkOption {
+        description = ''
+          A list of commands to run on mounted drives.
+
+          You can use the following placeholders:
+            %d    mount point directory (eg /media/cd)
+            %f    device name (eg /dev/sdd1)
+            %l    label of mounted volume
+        '';
+        example = [ "/path/to/script %d" ];
+        default = [ ];
+        type = with types; listOf str;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ udevil ];
+
+    systemd.user.services.devmon = {
+      description = "devmon automatic device mounting daemon";
+      wantedBy = [ "default.target" ];
+      path = with pkgs; [ udevil procps udisks2 which ];
+      serviceConfig.ExecStart = let
+        args = map (command: ''--exec-on-drive "${command}"'') cfg.execOnDrive;
+      in toString ([ "${pkgs.udevil}/bin/devmon" ] ++ args);
+    };
+
+    services.udisks2.enable = true;
+  };
+}

--- a/modules/services/automount.nix
+++ b/modules/services/automount.nix
@@ -35,7 +35,8 @@ in {
       wantedBy = [ "default.target" ];
       path = with pkgs; [ udevil procps udisks2 which ];
       serviceConfig.ExecStart = let
-        args = map (command: ''--exec-on-drive "${command}"'') cfg.execOnDrive;
+        systemdEscape = command: builtins.replaceStrings [ "%" ] [ "%%" ] command;
+        args = map (command: ''--exec-on-drive "${systemdEscape command}"'') cfg.execOnDrive;
       in toString ([ "${pkgs.udevil}/bin/devmon" ] ++ args);
     };
 

--- a/modules/system/holo-nixpkgs/usb-reset.nix
+++ b/modules/system/holo-nixpkgs/usb-reset.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.system.holo-nixpkgs.usbReset;
+  checkUsbReset = pkgs.writeShellScriptBin "check-usb-reset" ''
+    if [ -f "$1/${cfg.filename}" ]; then
+      rm -f "$1/${cfg.filename}"
+      ${pkgs.hpos-reset}/bin/hpos-reset
+    fi
+  '';
+
+in {
+  options = {
+    system.holo-nixpkgs.usbReset = {
+      enable = mkEnableOption "resetting when a special USB drive is connected";
+
+      filename = mkOption {
+        description = "Name of the file to look for.";
+        type = types.str;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.automount.execOnDrive = [ "${checkUsbReset}/bin/check-usb-reset %d" ];
+  };
+}

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -240,7 +240,8 @@ in
   };
 
   hpos-reset = writeShellScriptBin "hpos-reset" ''
-    rm -rf /var && reboot
+    rm -rf /var 
+    reboot
   '';
 
   hydra = previous.hydra.overrideAttrs (

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -218,6 +218,11 @@ in
     dates = "*:0/10";
   };
 
+  system.holo-nixpkgs.usbReset = {
+    enable = lib.mkDefault true;
+    filename = "hpos-reset";
+  };
+
   systemd.services.acme-default.serviceConfig.ExecStart =
     lib.mkForce "${holo-router-acme}/bin/holo-router-acme";
 

--- a/profiles/logical/hpos/sandbox/default.nix
+++ b/profiles/logical/hpos/sandbox/default.nix
@@ -17,4 +17,6 @@
   services.zerotierone.enable = false;
 
   system.holo-nixpkgs.autoUpgrade.enable = false;
+
+  system.holo-nixpkgs.usbReset.enable = false;
 }

--- a/profiles/physical/hpos/automount.nix
+++ b/profiles/physical/hpos/automount.nix
@@ -1,7 +1,0 @@
-{ pkgs, ... }:
-
-{
-  environment.systemPackages = [ pkgs.udevil ];
-
-  services.devmon.enable = true;
-}

--- a/profiles/physical/hpos/holoport-nano/default.nix
+++ b/profiles/physical/hpos/holoport-nano/default.nix
@@ -3,7 +3,6 @@
 {
   imports = [
     ../.
-    ../automount.nix
   ];
 
   boot.extraModulePackages = with config.boot.kernelPackages; [
@@ -28,6 +27,8 @@
   boot.loader.grub.enable = false;
 
   hardware.deviceTree.package = pkgs.holoport-nano-dtb;
+
+  services.automount.enable = true;
 
   services.hpos-led-manager.devicePath = "/dev/ttyS2";
 }

--- a/profiles/physical/hpos/holoport-plus/default.nix
+++ b/profiles/physical/hpos/holoport-plus/default.nix
@@ -3,11 +3,12 @@
 {
   imports = [
     ../.
-    ../automount.nix
     ../inferred-grub.nix
   ];
 
   boot.loader.grub.enable = lib.mkDefault true;
+
+  services.automount.enable = true;
 
   services.hpos-led-manager.devicePath = "/dev/ttyUSB0";
 }

--- a/profiles/physical/hpos/holoport/default.nix
+++ b/profiles/physical/hpos/holoport/default.nix
@@ -3,11 +3,12 @@
 {
   imports = [
     ../.
-    ../automount.nix
     ../inferred-grub.nix
   ];
 
   boot.loader.grub.enable = lib.mkDefault true;
+
+  services.automount.enable = true;
 
   services.hpos-led-manager.devicePath = "/dev/ttyUSB0";
 }


### PR DESCRIPTION
Close #188.

`services.devmon.enable` is defined by [profiles/physical/hpos/automount.nix](https://github.com/Holo-Host/holo-nixpkgs/blob/develop/profiles/physical/hpos/automount.nix#L6). If it's enabled, we add an argument `--exec-on-drive` to `ExecStart` (see [`devmon --help`](https://igurublog.wordpress.com/downloads/script-devmon/)).

This executes the script on the mountpoint after `devmon` has finished mounting the drive. This ensures proper unmounting/etc.