### PR TITLE
holochain-conductor: add hostedDnas

### DIFF
--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -23,6 +23,12 @@ let
     sha256 = "1i43k1wwcpmvx60db2kvbsvfihkfy2nn6iqqwcxz00gqm6pihr2q";
   };
 
+  hosted-holofuel = fetchurl {
+    url = "https://holo-host.github.io/holofuel/releases/download/v0.20.1/holofuel.dna.json";
+    name = "holofuel.dna.json";
+    sha256 = "159g4d0fhmb4kfi7v4ndizamj6ajfmxxv57ylzkr9q8sdyjb5l8i";
+  };
+
   servicelogger = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "servicelogger";
@@ -39,4 +45,6 @@ in
   inherit (callPackage servicelogger {}) servicelogger;
 
   holofuel = wrapDNA holofuel;
+
+  hosted-holofuel = wrapDNA hosted-holofuel;
 }

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -23,6 +23,7 @@ let
   conductorHome = "/var/lib/holochain-conductor";
 
   dnas = with dnaPackages; [
+    # list self hosted DNAs here
     # happ-store
     # holo-hosting-app
     holofuel
@@ -33,12 +34,30 @@ let
     id = drv.name;
     file = "${drv}/${drv.name}.dna.json";
     hash = pkgs.dnaHash drv;
+    holo-hosted = false;
+  };
+
+  hostedDnas = with dnaPackages; [
+    # list holo hosted DNAs here
+    {
+      drv = holofuel;
+      happ-url = "https://holofuel.holo.host";
+    }
+  ];
+
+  hostedDnaConfig = dna: rec {
+    id = pkgs.dnaHash dna.drv;
+    file = "${dna.drv}/${dna.drv.name}.dna.json";
+    hash = id;
+    holo-hosted = true;
+    happ-url = dna.happ-url;
   };
 
   instanceConfig = drv: {
     agent = "host-agent";
     dna = drv.name;
     id = drv.name;
+    holo-hosted = false;
     storage = {
       path = "${conductorHome}/${drv.name}-${pkgs.dnaHash drv}";
       type = "lmdb";
@@ -163,7 +182,7 @@ in
         }
       ];
       bridges = [];
-      dnas = map dnaConfig dnas;
+      dnas = map dnaConfig dnas ++ map hostedDnaConfig hostedDnas;
       instances = map instanceConfig dnas;
       network = {
         type = "sim2h";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -40,7 +40,7 @@ let
   hostedDnas = with dnaPackages; [
     # list holo hosted DNAs here
     {
-      drv = holofuel;
+      drv = hosted-holofuel;
       happ-url = "https://holofuel.holo.host";
     }
   ];


### PR DESCRIPTION
Adds HPOS configuration that imports and installs hosted DNAs, with hosted-holofuel as an example.