### PR TITLE
Fix Hydra setup

### DIFF
--- a/profiles/logical/binary-cache.nix
+++ b/profiles/logical/binary-cache.nix
@@ -4,6 +4,8 @@
   ];
 
   nix.binaryCachePublicKeys = [
+    # deprecated
     "cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE="
+    "cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ="
   ];
 }

--- a/profiles/logical/holo/hydra/master/default.nix
+++ b/profiles/logical/holo/hydra/master/default.nix
@@ -3,6 +3,8 @@
 let
   wasabiBucket = "cache.holo.host";
   wasabiEndpoint = "s3.wasabisys.com";
+  # TODO: bring into proper hydra module
+  signingKeyName = "cache.holo.host-2";
 in
 
 {
@@ -68,7 +70,7 @@ in
       max_concurrent_evals = 12
       max_output_size = 17179869184
       server_store_uri = https://cache.holo.host?local-nar-cache=/var/cache/hydra/nar-cache
-      store_uri = s3://${wasabiBucket}?endpoint=${wasabiEndpoint}&log-compression=br&ls-compression=br&parallel-compression=1&secret-key=/var/lib/hydra/queue-runner/keys/cache.holo.host-1/secret&write-nar-listing=1
+      store_uri = s3://${wasabiBucket}?endpoint=${wasabiEndpoint}&log-compression=br&ls-compression=br&parallel-compression=1&secret-key=/var/lib/hydra/queue-runner/keys/${signingKeyName}/secret&write-nar-listing=1
       upload_logs_to_binary_cache = true
 
       <githubstatus>

--- a/profiles/logical/holo/hydra/minion/default.nix
+++ b/profiles/logical/holo/hydra/minion/default.nix
@@ -4,6 +4,6 @@
   imports = [ ../. ];
 
   users.users.root.openssh.authorizedKeys.keys = lib.mkForce [
-    ''command="nix-store --serve --write" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE/SlkjHXwID8sIXRAkpqeB17S3J0ie27MXoVs8BTb5S''
+    ''command="nix-store --serve --write" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN5CNQRWNXgvrdFrzrQ3UsLqTTb8wX8BnY3PHKXb9s29 hydra.holo.host''
   ];
 }


### PR DESCRIPTION
- Add cache.holo.host-2 to binaryCachePublicKeys 
  - `cache.holo.host-1` is deprecated (e.g. private key won't ever be used again).
  - `cache.holo.host-2` is the new key (on Hydra), with which all new builds will be signed.