### PR TITLE
[backport] Add cache.holo.host-2 to binaryCachePublicKeys

### DIFF
--- a/profiles/logical/binary-cache.nix
+++ b/profiles/logical/binary-cache.nix
@@ -4,6 +4,8 @@
   ];
 
   nix.binaryCachePublicKeys = [
+    # deprecated
     "cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE="
+    "cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ="
   ];
 }


### PR DESCRIPTION
Backport of new public key from #448 to `master`.