### PR TITLE
[staging] Add cache.holo.host-2 to binaryCachePublicKeys

### DIFF
--- a/profiles/logical/binary-cache.nix
+++ b/profiles/logical/binary-cache.nix
@@ -4,6 +4,8 @@
   ];
 
   nix.binaryCachePublicKeys = [
+    # deprecated
     "cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE="
+    "cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ="
   ];
 }


### PR DESCRIPTION
cache.holo.host-1 is deprecated (e.g. private key won't ever be used again).
cache.holo.host-2 is the new key (on Hydra), with which all new builds will be signed.

Cherry-pick of #454 on `staging`.