### PR TITLE
profiles/hpos/development: create

### DIFF
--- a/modules/services/holochain-conductor.nix
+++ b/modules/services/holochain-conductor.nix
@@ -31,7 +31,7 @@ in
         ${pkgs.hpos-config-into-keystore}/bin/hpos-config-into-keystore \
           < $HPOS_CONFIG_PATH > /tmp/holo-keystore 2> /tmp/holo-keystore.pub
         export HOLO_KEYSTORE_HCID=$(cat /tmp/holo-keystore.pub)
-        if [[ ! -f $STATE_DIRECTORY/conductor-config.toml || $HPOS_DEVELOPMENT_MODE -ne "true" ]]; then
+        if [[ ! -f $STATE_DIRECTORY/conductor-config.toml || ! -n $HPOS_DEVELOPMENT_MODE ]]; then
           ${pkgs.envsubst}/bin/envsubst < ${pkgs.writeTOML cfg.config} \
             | ${pkgs.holo-update-conductor-config}/bin/holo-update-conductor-config \
             $STATE_DIRECTORY/conductor-config.toml

--- a/modules/services/holochain-conductor.nix
+++ b/modules/services/holochain-conductor.nix
@@ -31,7 +31,7 @@ in
         ${pkgs.hpos-config-into-keystore}/bin/hpos-config-into-keystore \
           < $HPOS_CONFIG_PATH > /tmp/holo-keystore 2> /tmp/holo-keystore.pub
         export HOLO_KEYSTORE_HCID=$(cat /tmp/holo-keystore.pub)
-        if [ ! -f $STATE_DIRECTORY/conductor-config.toml || ! $HPOS_DEVELOPMENT_MODE ]; then
+        if [[ ! -f $STATE_DIRECTORY/conductor-config.toml || $HPOS_DEVELOPMENT_MODE -ne "true" ]]; then
           ${pkgs.envsubst}/bin/envsubst < ${pkgs.writeTOML cfg.config} \
             | ${pkgs.holo-update-conductor-config}/bin/holo-update-conductor-config \
             $STATE_DIRECTORY/conductor-config.toml

--- a/modules/services/holochain-conductor.nix
+++ b/modules/services/holochain-conductor.nix
@@ -31,9 +31,11 @@ in
         ${pkgs.hpos-config-into-keystore}/bin/hpos-config-into-keystore \
           < $HPOS_CONFIG_PATH > /tmp/holo-keystore 2> /tmp/holo-keystore.pub
         export HOLO_KEYSTORE_HCID=$(cat /tmp/holo-keystore.pub)
-        ${pkgs.envsubst}/bin/envsubst < ${pkgs.writeTOML cfg.config} \
-          | ${pkgs.holo-update-conductor-config}/bin/holo-update-conductor-config \
-          $STATE_DIRECTORY/conductor-config.toml
+        if [ ! -f $STATE_DIRECTORY/conductor-config.toml || ! $HPOS_DEVELOPMENT_MODE ]; then
+          ${pkgs.envsubst}/bin/envsubst < ${pkgs.writeTOML cfg.config} \
+            | ${pkgs.holo-update-conductor-config}/bin/holo-update-conductor-config \
+            $STATE_DIRECTORY/conductor-config.toml
+        fi
       '';
 
       serviceConfig = {

--- a/profiles/logical/hpos/development/default.nix
+++ b/profiles/logical/hpos/development/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [ ../. ];
+
+  environment.variables.HPOS_DEVELOPMENT_MODE = true;
+}

--- a/profiles/logical/hpos/development/default.nix
+++ b/profiles/logical/hpos/development/default.nix
@@ -1,5 +1,5 @@
 {
   imports = [ ../. ];
 
-  environment.variables.HPOS_DEVELOPMENT_MODE = true;
+  environment.variables.HPOS_DEVELOPMENT_MODE = "true";
 }


### PR DESCRIPTION
- Add `$HPOS_DEVELOPMENT_MODE` to global environment
- Check this variable in `preStart` of `holochain-conductor.service`