### PR TITLE
profiles/hpos: rm symlinks in preStart of timesyncd (#460)

### DIFF
--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -247,7 +247,7 @@ in
 
   # FIXME: see https://github.com/NixOS/nixpkgs/issues/31540
   systemd.services.systemd-timesyncd.preStart = ''
-    rm -rf /var/lib/{private/,}systemd/timesyncd
+    rm -rf /var/lib/{private/,}systemd/timesync
   '';
 
   system.stateVersion = "19.09";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -245,6 +245,11 @@ in
   systemd.services.acme-default.serviceConfig.ExecStart =
     lib.mkForce "${holo-router-acme}/bin/holo-router-acme";
 
+  # FIXME: see https://github.com/NixOS/nixpkgs/issues/31540
+  systemd.services.systemd-timesyncd.preStart = ''
+    rm -rf /var/lib/{private/,}systemd/timesyncd
+  '';
+
   system.stateVersion = "19.09";
 
   users.users.nginx.extraGroups = [ "hpos-admin-users" ];


### PR DESCRIPTION
Close #460.

See https://github.com/NixOS/nixpkgs/issues/31540.