### PR TITLE
Update to holochain-rust v0.0.48-alpha1

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -49,8 +49,8 @@ let
   hp-admin = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hp-admin";
-    rev = "8d46c49dd742bfd8f45590fa5bf882fd120d6d76";
-    sha256 = "16h52858d7glscqpc0vyd9f1shi8z7b65vgqv4ascg58gjx68pvl";
+    rev = "d612a6b916d13c718d6a2bc87387665eee7ad550";
+    sha256 = "0yp3dakm7df6lkyjc4zr0paskvyhzamivakzjgqv3jfvgradba0r";
   };
 
   hp-admin-crypto = fetchFromGitHub {
@@ -315,6 +315,8 @@ in
       };
     };
   };
+
+  wasm-pack = callPackage ./wasm-pack {};
 
   wrangler = callPackage ./wrangler {};
 

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -11,9 +11,9 @@ let
   };
 
   holofuel = fetchurl {
-    url = "https://holo-host.github.io/holofuel/releases/download/v0.20.1/holofuel.dna.json";
+    url = "https://holo-host.github.io/holofuel/releases/download/v0.20.3-alpha1/holofuel.dna.json";
     name = "holofuel.dna.json";
-    sha256 = "159g4d0fhmb4kfi7v4ndizamj6ajfmxxv57ylzkr9q8sdyjb5l8i";
+    sha256 = "1aanyqlj4zvxpzwdjw6wk100b1ln8mp14pr6m8ib95bs6bj8jacg";
   };
 
   holo-hosting-app = fetchFromGitHub {
@@ -21,6 +21,12 @@ let
     repo = "holo-hosting-app";
     rev = "37013a19c4f2546304e2abea6951e2e06863fcbc";
     sha256 = "1i43k1wwcpmvx60db2kvbsvfihkfy2nn6iqqwcxz00gqm6pihr2q";
+  };
+
+  hosted-holofuel = fetchurl {
+    url = "https://holo-host.github.io/holofuel/releases/download/v0.20.3-alpha1/holofuel.dna.json";
+    name = "holofuel.dna.json";
+    sha256 = "1aanyqlj4zvxpzwdjw6wk100b1ln8mp14pr6m8ib95bs6bj8jacg";
   };
 
   servicelogger = fetchFromGitHub {
@@ -39,4 +45,6 @@ in
   inherit (callPackage servicelogger {}) servicelogger;
 
   holofuel = wrapDNA holofuel;
+
+  hosted-holofuel = wrapDNA hosted-holofuel;
 }

--- a/overlays/holo-nixpkgs/holochain-rust/default.nix
+++ b/overlays/holo-nixpkgs/holochain-rust/default.nix
@@ -6,11 +6,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "holochain-rust";
-    rev = "v0.0.46-alpha1";
-    sha256 = "00pw5gn0pwxl67nmj8r0q1s3zbhilis2hvrxvrgachkjmb1a5bj1";
+    rev = "v0.0.48-alpha1";
+    sha256 = "1lzg1s36zycniaarc6j6mkx8bakg5l2n38qxm38wdw0cc67i4xbr";
   };
 
-  cargoSha256 = "0d7pzs3d42pph1ffm7kyq7qdhzqngvpjr60r82mh37nld3kvrhyz";
+  cargoSha256 = "1kj0fyh12lckgb5p09fvh2bh522nsaad6jgm420jx8ihqvx5fn2y";
 
   nativeBuildInputs = [ perl ];
 

--- a/overlays/holo-nixpkgs/wasm-pack/default.nix
+++ b/overlays/holo-nixpkgs/wasm-pack/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkgconfig
+, libressl
+, curl
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wasm-pack";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "rustwasm";
+    repo = "wasm-pack";
+    rev = "v${version}";
+    sha256 = "1rqyfg6ajxxyfx87ar25nf5ck9hd0p12qgv98dicniqag8l4rvsr";
+  };
+
+  cargoSha256 = "095gk6lcck5864wjhrkhgnkxn9pzcg82xk5p94br7lmf15y9gc7j";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [
+    # LibreSSL works around segfault issues caused by OpenSSL being unable to
+    # gracefully exit while doing work.
+    # See: https://github.com/rustwasm/wasm-pack/issues/650
+    curl
+    libressl
+  ] ++ stdenv.lib.optionals stdenv.isDarwin (
+    with darwin.apple_sdk.frameworks; [
+      Security
+    ]
+  );
+
+  # Most tests rely on external resources and build artifacts.
+  # Disabling check here to work with build sandboxing.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A utility that builds rust-generated WebAssembly package";
+    homepage = "https://github.com/rustwasm/wasm-pack";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = [ maintainers.dhkl ];
+    platforms = platforms.all;
+  };
+}

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -39,10 +39,10 @@ let
 
   hostedDnas = with dnaPackages; [
     # list holo hosted DNAs here
-    #{
-    #  drv = hosted-holofuel;
-    #  happ-url = "https://holofuel.holo.host";
-    #}
+    {
+      drv = hosted-holofuel;
+      happ-url = "https://holofuel.holo.host";
+    }
   ];
 
   hostedDnaConfig = dna: rec {


### PR DESCRIPTION
    o Update wasm-pack to 0.9.1, needed to build browser/nodejs compatible wasm modules
    o Adds hosted-holofuel