### PR TITLE
profiles/hpos/nginx: add URI to /hosting/ proxyPass rule

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -11,6 +11,7 @@
     ./services/holochain-conductor.nix
     ./services/hp-admin-crypto-server.nix
     ./services/hpos-admin.nix
+    ./services/holo-envoy.nix
     ./services/hpos-init.nix
     ./services/hpos-led-manager.nix
     ./services/magic-wormhole-mailbox-server.nix

--- a/modules/services/holo-envoy.nix
+++ b/modules/services/holo-envoy.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.holo-envoy;
+in
+
+{
+  options.services.holo-envoy = {
+    enable = mkEnableOption "Holo Envoy";
+
+    package = mkOption {
+      default = pkgs.holo-envoy;
+      type = types.package;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.holo-envoy = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/holo-envoy";
+      };
+    };
+  };
+}

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -35,8 +35,8 @@ let
   holo-envoy = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-envoy";
-    rev = "9ca258beb945d1377df7b2b76e6642e24ca4470e";
-    sha256 = "06nmwr623wxi5vvzsk17z1pc38maw7xp1wd4khnda3ds9gkgm52y";
+    rev = "a551e441ac966cf04c23453efba4e5191a78c7fb";
+    sha256 = "1r6vjs3ycw4q3d23w3ik5zxcghqzks27147s78p4pg2gb0fxsvn0";
   };
 
   holo-router = fetchFromGitHub {

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -32,6 +32,13 @@ let
     sha256 = "1c8p9xjhfxgh11vf55fwkglffv0qjc8gzc98kybqznhm81l8y2fl";
   };
 
+  holo-envoy = fetchFromGitHub {
+    owner = "Holo-Host";
+    repo = "holo-envoy";
+    rev = "9ca258beb945d1377df7b2b76e6642e24ca4470e";
+    sha256 = "06nmwr623wxi5vvzsk17z1pc38maw7xp1wd4khnda3ds9gkgm52y";
+  };
+
   holo-router = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-router";
@@ -87,6 +94,10 @@ in
   inherit (callPackage gitignore {}) gitignoreSource;
 
   inherit (callPackage holo-auth {}) holo-auth-client;
+  
+  inherit (callPackage holo-envoy {})
+    holo-envoy
+    ;
 
   inherit (callPackage holo-router {})
     holo-router-agent

--- a/overlays/holo-nixpkgs/dna-packages/default.nix
+++ b/overlays/holo-nixpkgs/dna-packages/default.nix
@@ -16,6 +16,12 @@ let
     sha256 = "159g4d0fhmb4kfi7v4ndizamj6ajfmxxv57ylzkr9q8sdyjb5l8i";
   };
 
+  hosted-holofuel = fetchurl {
+    url = "https://holo-host.github.io/holofuel/releases/download/v0.14.4-alpha1/holofuel.dna.json";
+    name = "holofuel.dna.json";                                         
+    sha256 = "1bzrmw3v0kf6q76s6h56cyxv5axjcjd0axpkbkp07y7cdd8s356r";    
+  };
+
   holo-hosting-app = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-hosting-app";
@@ -39,4 +45,6 @@ in
   inherit (callPackage servicelogger {}) servicelogger;
 
   holofuel = wrapDNA holofuel;
+
+  hosted-holofuel = wrapDNA hosted-holofuel;
 }

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -94,6 +94,8 @@ in
 
   services.holo-auth-client.enable = lib.mkDefault true;
 
+  services.holo-envoy.enable = true;
+
   services.holo-router-agent.enable = lib.mkDefault true;
 
   services.hp-admin-crypto-server.enable = true;

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -196,6 +196,8 @@ in
       };
       persistence_dir = conductorHome;
       signing_service_uri = "http://localhost:9676";
+      encryption_service_uri = "http://localhost:9676";
+      decryption_service_uri = "http://localhost:9676";
       interfaces = [
         {
           id = "master-interface";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -161,7 +161,7 @@ in
         };
 
         "/hosting/" = {
-          proxyPass = "http://127.0.0.1:4656";
+          proxyPass = "http://127.0.0.1:4656/hosting/";
           proxyWebsockets = true;
         };
       };

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -39,10 +39,10 @@ let
 
   hostedDnas = with dnaPackages; [
     # list holo hosted DNAs here
-    #{
-    #  drv = hosted-holofuel;
-    #  happ-url = "https://holofuel.holo.host";
-    #}
+    {
+     drv = hosted-holofuel;
+     happ-url = "http://hostedtestfuel.holo.host";
+    }
   ];
 
   hostedDnaConfig = dna: rec {


### PR DESCRIPTION
This tries to fix an error where envoy registers methods for ws-rpc in a wrong namespace, therefore those methods show to the external world as not registered