### PR TITLE
Add descriptive fields for Holo hosted hApps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-.github/ @peeech
-modules/ @peeech
-profiles/ @peeech
+.github/ @peeech @filalex77
+modules/ @peeech @filalex77
+profiles/ @peeech @filalex77

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -58,3 +58,21 @@ branches:
         users:
           - peeech
         teams: []
+  - name: hydra
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        dismissal_restrictions:
+          users: []
+          teams: []
+      required_status_checks:
+        strict: true
+        contexts:
+          - Hydra
+      enforce_admins: true
+      restrictions:
+        users:
+          - peeech
+        teams: []

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -39,6 +39,7 @@ branches:
       restrictions:
         users:
           - peeech
+          - filalex77
         teams: []
   - name: master
     protection:
@@ -57,6 +58,7 @@ branches:
       restrictions:
         users:
           - peeech
+          - filalex77
         teams: []
   - name: hydra
     protection:
@@ -75,4 +77,5 @@ branches:
       restrictions:
         users:
           - peeech
+          - filalex77
         teams: []

--- a/README.md
+++ b/README.md
@@ -71,5 +71,18 @@ https://hydra.holo.host/job/holo-nixpkgs/master/holoportos.targets.virtualbox.x8
 
 Refer to [VirtualBox manual, chapter 1, section 1.15.2](https://www.virtualbox.org/manual/ch01.html#ovf-import-appliance).
 
-[nix]: https://nixos.org/nix/
+## HPOS profiles
+
+There's a number of profiles you can activate on your HPOS that alter behavior of your machine. They are listed in `profiles/logical/hpos/README.md`. To activate given profile on your machine add their location to the list of `imports` in `/etc/nixos/configuration.nix`. For example to activate `development` profile modify your `imports` to read:
+```nix
+{
+  imports = [
+    <holo-nixpkgs/profiles/targets/holoport>
+    <holo-nixpkgs/profiles/logical/hpos/development>
+    ./hardware-configuration.nix
+  ];
+
+  ...
+}
+```
 <!-- :) -->

--- a/jobsets.nix
+++ b/jobsets.nix
@@ -5,6 +5,6 @@ with pkgs;
 mkJobsets {
   owner = "Holo-Host";
   repo = "holo-nixpkgs";
-  branches = [ "develop" "master" "staging" ];
+  branches = [ "develop" "master" "staging" "hydra" ];
   pullRequests = <holo-nixpkgs-pull-requests>;
 }

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -169,8 +169,6 @@ in
     ${remarshal}/bin/json2toml < ${writeJSON config} > $out
   '';
 
-  bump-dna = callPackage bump-dna {};
-
   dnaHash = dna: builtins.readFile (
     runCommand "${dna.name}-hash" {} ''
       ${holochain-rust}/bin/hc hash -p ${dna}/${dna.name}.dna.json \

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -11,6 +11,13 @@ let
     sha256 = "00d9c6f0hh553hgmw01lp5639kbqqyqsz66jz35pz8xahmyk5wmw";
   };
 
+  bump-dna = fetchFromGitHub {
+    owner = "Holo-Host";
+    repo = "bump-dna";
+    rev = "f97d963a3cef41b30a646ada9ba55349d104ed2c";
+    sha256 = "1kpa3r8cwik9r3k3l6p1n3cl0g4bqwm0wp23mgr4ac41x7xpndyk";
+  };
+
   cargo-to-nix = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "cargo-to-nix";
@@ -78,6 +85,8 @@ in
     aorura-cli
     aorura-emu
     ;
+
+  inherit (callPackage bump-dna {}) bump-dna-cli;
 
   inherit (callPackage cargo-to-nix {})
     buildRustPackage
@@ -159,6 +168,8 @@ in
   writeTOML = config: runCommand "config.toml" {} ''
     ${remarshal}/bin/json2toml < ${writeJSON config} > $out
   '';
+
+  bump-dna = callPackage bump-dna {};
 
   dnaHash = dna: builtins.readFile (
     runCommand "${dna.name}-hash" {} ''

--- a/profiles/logical/holo/hydra/master/default.nix
+++ b/profiles/logical/holo/hydra/master/default.nix
@@ -67,7 +67,7 @@ in
       binary_cache_public_uri = https://cache.holo.host
       evaluator_max_heap_size = ${toString (4 * 1024 * 1024 * 1024)}
       log_prefix = https://cache.holo.host/
-      max_concurrent_evals = 12
+      max_concurrent_evals = 3
       max_output_size = 17179869184
       server_store_uri = https://cache.holo.host?local-nar-cache=/var/cache/hydra/nar-cache
       store_uri = s3://${wasabiBucket}?endpoint=${wasabiEndpoint}&log-compression=br&ls-compression=br&parallel-compression=1&secret-key=/var/lib/hydra/queue-runner/keys/${signingKeyName}/secret&write-nar-listing=1

--- a/profiles/logical/hpos/README.md
+++ b/profiles/logical/hpos/README.md
@@ -1,0 +1,6 @@
+# HPOS Profiles
+
+Main HPOS profile (located in default.nix) sets up services for production ready HoloPort. Other profiles (located in subfolders) add certain functionality to HPOS:
+- development - disables automatic rebuild of Holochain conductor configuration with each system restart
+- sandbox - disables HPOS registration services and enables local sim2h server
+- staged - enables ssh access to HPOS to users listed in `staged/authorized_keys`

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -42,6 +42,10 @@ let
     #{
     #  drv = hosted-holofuel;
     #  happ-url = "https://holofuel.holo.host";
+    #  happ-title = "HoloFuel";
+    #  happ-release-version = "v0.1";
+    #  happ-publisher = "Holo Ltd";
+    #  happ-publish-date = "2020/01/31";
     #}
   ];
 
@@ -51,6 +55,10 @@ let
     hash = id;
     holo-hosted = true;
     happ-url = dna.happ-url;
+    happ-title = dna.happ-title;
+    happ-release-version = dna.happ-release-version;
+    happ-publisher = dna.happ-publisher;
+    happ-publish-date = dna.happ-publish-date;
   };
 
   instanceConfig = drv: {

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -78,7 +78,7 @@ in
 
   environment.noXlibs = true;
 
-  environment.systemPackages = [ hpos-reset ];
+  environment.systemPackages = [ hpos-reset bump-dna-cli ];
 
   networking.firewall.allowedTCPPorts = [ 443 ];
 

--- a/shell.nix
+++ b/shell.nix
@@ -28,5 +28,6 @@ mkShell {
     "holo-nixpkgs=${root}"
     "nixpkgs=${pkgs.path}"
     "nixpkgs-overlays=${root}/overlays"
+    "nixos-config=/etc/nixos/configuration.nix"
   ];
 }


### PR DESCRIPTION
Adds:
- title
- publisher
- publish date
- release version

To hosted hApps in conductor-config.toml so that HP admin can access them
These fields are supposed to be arbitrary strings with no function