### PR TITLE
Add endpoint to trigger a factory reset via HP admin API

### DIFF
--- a/overlays/holo-nixpkgs/hpos-admin-client/hpos-admin-client.py
+++ b/overlays/holo-nixpkgs/hpos-admin-client/hpos-admin-client.py
@@ -52,5 +52,13 @@ def get_status(ctx):
     print(request(params, 'GET', '/status').json())
 
 
+@cli.command(help='Initiate a factory reset')
+@click.pass_context
+def factory_reset(ctx):
+    res = request(ctx, 'POST', '/reset')
+    if res.status_code == 400:
+        print("Failed to reset device")
+
+
 if __name__ == '__main__':
     cli(obj={})

--- a/overlays/holo-nixpkgs/hpos-admin/default.nix
+++ b/overlays/holo-nixpkgs/hpos-admin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, python3, hpos-config-is-valid, zerotierone }:
+{ stdenv, makeWrapper, python3, hpos-config-is-valid, zerotierone, hpos-reset }:
 
 with stdenv.lib;
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildCommand = ''
     makeWrapper ${python3}/bin/python3 $out/bin/${name} \
       --add-flags ${./hpos-admin.py} \
-      --prefix PATH : ${makeBinPath [ hpos-config-is-valid zerotierone ]}
+      --prefix PATH : ${makeBinPath [ hpos-config-is-valid zerotierone hpos-reset ]}
   '';
 
   meta.platforms = platforms.linux;

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -104,6 +104,14 @@ def upgrade():
     return '', 200
 
 
+@app.route('/reset', methods=['POST'])
+def reset():
+    try:
+        subprocess.run(['hpos-reset'], check=True)
+    except CalledProcessError:
+        return '', 400
+
+
 def unix_socket(path):
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     if os.path.exists(path):

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -109,7 +109,7 @@ def reset():
     try:
         subprocess.run(['hpos-reset'], check=True)
     except CalledProcessError:
-        return '', 400
+        return '', 500
 
 
 def unix_socket(path):


### PR DESCRIPTION
To call `hpos-reset` via HP Admin. Currently not passing tests