### PR TITLE
HP Admin return number of hosted instances per happ

### DIFF
--- a/overlays/holo-nixpkgs/hpos-admin-client/hpos-admin-client.py
+++ b/overlays/holo-nixpkgs/hpos-admin-client/hpos-admin-client.py
@@ -49,7 +49,13 @@ def put_settings(ctx, k, v):
 @cli.command(help='Get HoloPortOS status data')
 @click.pass_context
 def get_status(ctx):
-    print(request(params, 'GET', '/status').json())
+    print(request(ctx, 'GET', '/status').json())
+
+
+@cli.command(help='Get info on happs currently hosted')
+@click.pass_context
+def get_hosted_happs(ctx):
+    print(request(ctx, 'GET', '/hosted_happs').json())
 
 
 if __name__ == '__main__':

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -77,6 +77,9 @@ def hosted_happs():
     conductor_config = toml.load('/var/lib/holochain-conductor/conductor-config.toml')
     [dna for dna in conductor_config['dnas'] if dna['holo-hosted']]
 
+def hosted_instances():
+    conductor_config = toml.load('/var/lib/holochain-conductor/conductor-config.toml')
+    [instance for instance in conductor_config['instances'] if instance['holo-hosted']]
 
 @app.route('/hosted_happs', methods=['GET'])
 def get_hosted_happs():

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -75,16 +75,30 @@ def put_settings():
 
 def hosted_happs():
     conductor_config = toml.load('/var/lib/holochain-conductor/conductor-config.toml')
-    [dna for dna in conductor_config['dnas'] if dna['holo-hosted']]
+    return [dna for dna in conductor_config['dnas'] if dna['holo-hosted']]
+
 
 def hosted_instances():
     conductor_config = toml.load('/var/lib/holochain-conductor/conductor-config.toml')
-    [instance for instance in conductor_config['instances'] if instance['holo-hosted']]
+    return [instance for instance in conductor_config['instances'] if instance['holo-hosted']]
+
 
 @app.route('/hosted_happs', methods=['GET'])
 def get_hosted_happs():
+
+    hosted_happs_list = hosted_happs()
+    hosted_instances_list = hosted_instances()
+    
+    if len(hosted_happs_list) > 0:
+        for hosted_happ in hosted_happs_list:
+            if len(hosted_instances_list) > 0:
+                num_instances = sum(hosted_happ['id'] == hosted_instance['id'] for hosted_instance in hosted_instances_list)
+            else: 
+                num_instances = 0
+            hosted_happ['number_instances'] = num_instances
+
     return jsonify({
-        'hosted_happs': hosted_happs()
+        'hosted_happs': hosted_happs_list
     })
 
 

--- a/tests/hpos-admin/conductor-config.toml
+++ b/tests/hpos-admin/conductor-config.toml
@@ -15,14 +15,14 @@ holo-hosted = true
 happ-url = 'www.test1.com'
 
 [[dnas]]
-file = 'bridge/callee.dna'
+file = 'bridge/callee.dna.json'
 hash = 'QmQ6zcwmVkcJ56A8aT7ptrJSDUsdwi7gt2KFtxJzQLzDX3'
-id = 'bridge-callee'
+id = 'QmQ6zcwmVkcJ56A8aT7ptrJSDUsdwi7gt2KFtxJzQLzDX3'
 holo-hosted = true
 happ-url = 'www.test2.com'
 
 [[dnas]]
-file = 'bridge/caller.dna'
+file = 'bridge/caller.dna.json'
 hash = 'QmWA2iEi5DkKSkDS83dAmtMYCYRy7iNPnxcNH3FM3c9whQ'
 id = 'bridge-caller'
 holo-hosted = false

--- a/tests/hpos-admin/conductor-config.toml
+++ b/tests/hpos-admin/conductor-config.toml
@@ -72,3 +72,12 @@ holo-hosted = false
 
 [instances.storage]
 type = 'memory'
+
+[[instances]]
+agent = 'test-agent-2'
+dna = 'QmWA2iEi5DkKSkDS83dAmtMYCYRy7iNPnxcNH3FM3c9whQ'
+id = 'QmWA2iEi5DkKSkDS83dAmtMYCYRy7iNPnxcNH3FM3c9whQ'
+holo-hosted = false
+
+[instances.storage]
+type = 'memory'

--- a/tests/hpos-admin/conductor-config.toml
+++ b/tests/hpos-admin/conductor-config.toml
@@ -1,0 +1,74 @@
+bridges = []
+persistence_dir = ".holochain/holo"
+
+[[agents]]
+id = "hp-admin-agent"
+keystore_file = "agent.key"
+name = "HP Admin"
+public_address = "HcSCjCvkR5uywn6z5t9SBFtTs7p83Ex3urUtpY8jsUa7pn3zdF6XJU4U6tuzpui"
+
+[[dnas]]
+file = 'app_spec.dna.json'
+hash = 'QmaJiTs75zU7kMFYDkKgrCYaH8WtnYNkmYX3tPt7ycbtRq'
+id = 'QmaJiTs75zU7kMFYDkKgrCYaH8WtnYNkmYX3tPt7ycbtRq'
+holo-hosted = true
+happ-url = 'www.test1.com'
+
+[[dnas]]
+file = 'bridge/callee.dna'
+hash = 'QmQ6zcwmVkcJ56A8aT7ptrJSDUsdwi7gt2KFtxJzQLzDX3'
+id = 'bridge-callee'
+holo-hosted = true
+happ-url = 'www.test2.com'
+
+[[dnas]]
+file = 'bridge/caller.dna'
+hash = 'QmWA2iEi5DkKSkDS83dAmtMYCYRy7iNPnxcNH3FM3c9whQ'
+id = 'bridge-caller'
+holo-hosted = false
+happ-url = ''
+
+[[instances]]
+agent = 'test-agent-1'
+dna = 'QmaJiTs75zU7kMFYDkKgrCYaH8WtnYNkmYX3tPt7ycbtRq'
+id = 'QmaJiTs75zU7kMFYDkKgrCYaH8WtnYNkmYX3tPt7ycbtRq'
+holo-hosted = true
+
+[instances.storage]
+type = 'memory'
+
+[[instances]]
+agent = 'test-agent-2'
+dna = 'QmaJiTs75zU7kMFYDkKgrCYaH8WtnYNkmYX3tPt7ycbtRq'
+id = 'QmaJiTs75zU7kMFYDkKgrCYaH8WtnYNkmYX3tPt7ycbtRq'
+holo-hosted = true
+
+[instances.storage]
+type = 'memory'
+
+[[instances]]
+agent = 'test-agent-3'
+dna = 'QmQ6zcwmVkcJ56A8aT7ptrJSDUsdwi7gt2KFtxJzQLzDX3'
+id = 'QmQ6zcwmVkcJ56A8aT7ptrJSDUsdwi7gt2KFtxJzQLzDX3'
+holo-hosted = true
+
+[instances.storage]
+type = 'memory'
+
+[[instances]]
+agent = 'test-agent-2'
+dna = 'QmWA2iEi5DkKSkDS83dAmtMYCYRy7iNPnxcNH3FM3c9whQ'
+id = 'QmWA2iEi5DkKSkDS83dAmtMYCYRy7iNPnxcNH3FM3c9whQ'
+holo-hosted = false
+
+[instances.storage]
+type = 'memory'
+
+[[instances]]
+agent = 'test-agent-1'
+dna = 'QmWA2iEi5DkKSkDS83dAmtMYCYRy7iNPnxcNH3FM3c9whQ'
+id = 'QmWA2iEi5DkKSkDS83dAmtMYCYRy7iNPnxcNH3FM3c9whQ'
+holo-hosted = false
+
+[instances.storage]
+type = 'memory'

--- a/tests/hpos-admin/default.nix
+++ b/tests/hpos-admin/default.nix
@@ -50,6 +50,21 @@ makeTest {
 
     die "unexpected settings" unless $actual_settings eq $expected_settings;
 
+    $machine->succeed(
+      "mkdir /var/lib/holochain-conductor && cp ${./conductor-config.toml} /var/lib/holochain-conductor/conductor-config.toml"
+    );
+
+    $machine->waitForFile("/var/lib/holochain-conductor/conductor-config.toml");
+    my $expected_hosted_happs = "{'hosted_happs': [" .
+        "{'file': 'app_spec.dna.json', 'happ-url': 'www.test1.com', 'hash': 'QmaJiTs75zU7kMFYDkKgrCYaH8WtnYNkmYX3tPt7ycbtRq', 'holo-hosted': True, 'id': 'QmaJiTs75zU7kMFYDkKgrCYaH8WtnYNkmYX3tPt7ycbtRq', 'number_instances': 2}, " .
+        "{'file': 'bridge/callee.dna.json', 'happ-url': 'www.test2.com', 'hash': 'QmQ6zcwmVkcJ56A8aT7ptrJSDUsdwi7gt2KFtxJzQLzDX3', 'holo-hosted': True, 'id': 'QmQ6zcwmVkcJ56A8aT7ptrJSDUsdwi7gt2KFtxJzQLzDX3', 'number_instances': 1}" .
+    "]}";
+
+    my $actual_hosted_happs = $machine->succeed("hpos-admin-client --url=http://localhost get-hosted-happs");
+    chomp($actual_hosted_happs); 
+
+    die "unexpected_hosted_happs_list" unless $actual_hosted_happs eq $expected_hosted_happs;
+
     $machine->shutdown;
   '';
 


### PR DESCRIPTION
Updates the `/hosted_happs` endpoint to also provide the number of hosted instances for each hosted_happ ID.