### PR TITLE
Add wormhole error handling to fix customer bug

### DIFF
--- a/overlays/holo-nixpkgs/hpos-init/hpos_init/main.py
+++ b/overlays/holo-nixpkgs/hpos-init/hpos_init/main.py
@@ -60,6 +60,8 @@ async def receive_config(backoff_exp=1):
         log.warning("receive failed with %s, retrying in %d seconds",
                     exc_type, backoff)
         reactor.callLater(backoff, receive_config, backoff_exp + 1)
+    except:
+        log.warning("Wormhole receive failed with %s, process will now terminate")
     finally:
         if os.path.exists(wormhole_code_path()):
             os.remove(wormhole_code_path())


### PR DESCRIPTION
Customer mrcat in China reports that their HoloPort cannot connect to our network. Screenshot suggests this is due to an unhandled error with Wormhole, which is a currently unused service set up for future VMs and Cloudports.

This is a basic error handler to address the issue for HP owners - we will probably need something more robust when Cloudports are operating.

![图片](https://user-images.githubusercontent.com/16625137/85392215-249e1e80-b543-11ea-8ff8-fe1abb133ba3.jpg)

Note that this nixOS project also had a very similar / the same issue and it may be caused with an unhandled error in the Twisted library.
https://github.com/Tribler/tribler/issues/3440#issuecomment-400987017