### PR TITLE
Allow HP admin to toggle HPOS features

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./profiles/development.nix
+    ./profiles/hpos-admin-features.nix
     ./services/aorura-emu.nix
     ./services/automount.nix
     ./services/dnscrypt-proxy2.nix

--- a/modules/profiles/hpos-admin-features.nix
+++ b/modules/profiles/hpos-admin-features.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hpos-admin-features;
+
+in
+
+{
+  options.hpos-admin-features = {
+    enable = mkOption {
+      description = "Whether to enable toggling of HPOS features by HP Admin";
+      type = types.bool;
+      default = true;
+    };
+
+    tomlPath = mkOption {
+      description = ''
+        A path to a TOML file containing feature settings.
+
+        Root of the TOML file should be a table with keys being
+        names of the profiles, e.g. "development".
+
+        Example:
+
+        [development.features]
+        ssh.enable = true
+      '';
+      type = types.path;
+      default = /etc/nixos/hpos-admin-features.toml;
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    systemd.paths.hpos-admin-features-rebuild = {
+      wantedBy = [ "multi-user.target" ];
+      pathConfig = {
+        PathModified = cfg.tomlPath;
+        Unit = "nixos-rebuild.service";
+      };
+    };
+
+    profiles = if (builtins.pathExists cfg.tomlPath) then
+      builtins.fromTOML (builtins.readFile cfg.tomlPath)
+      else {};
+  };
+}
+

--- a/modules/services/nixos-rebuild.nix
+++ b/modules/services/nixos-rebuild.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  systemd.services.nixos-rebuild = {
+    serviceConfig.Type = "oneshot";
+    unitConfig.X-StopOnRemoval = false;
+    restartIfChanged = false;
+
+    environment = config.nix.envVars // {
+      inherit (config.environment.sessionVariables) NIX_PATH;
+      HOME = "/root";
+    } // config.networking.proxy.envVars;
+
+    path = with pkgs; [ config.nix.package git gzip gnutar xz ];
+
+    script = ''
+      ${config.system.build.nixos-rebuild}/bin/nixos-rebuild switch
+    '';
+  };
+}
+

--- a/modules/system/holo-nixpkgs/auto-upgrade.nix
+++ b/modules/system/holo-nixpkgs/auto-upgrade.nix
@@ -16,15 +16,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    systemd.services.holo-nixpkgs-auto-upgrade = {
-      serviceConfig.Type = "oneshot";
-      unitConfig.X-StopOnRemoval = false;
-      restartIfChanged = false;
-
-      environment = config.nix.envVars // {
-        inherit (config.environment.sessionVariables) NIX_PATH;
-        HOME = "/root";
-      } // config.networking.proxy.envVars;
+    systemd.services.holo-nixpkgs-auto-upgrade = config.systemd.services.nixos-rebuild // {
 
       path = with pkgs; [ config.nix.package git gzip gnutar xz curl jq perl ];
 

--- a/modules/system/holo-nixpkgs/auto-upgrade.nix
+++ b/modules/system/holo-nixpkgs/auto-upgrade.nix
@@ -17,6 +17,7 @@ in
 
   config = mkIf cfg.enable {
     systemd.services.holo-nixpkgs-auto-upgrade = config.systemd.services.nixos-rebuild // {
+      after = [ "network.target" ];
 
       path = with pkgs; [ config.nix.package git gzip gnutar xz curl jq perl ];
 

--- a/overlays/holo-nixpkgs/hpos-admin-client/hpos-admin-client.py
+++ b/overlays/holo-nixpkgs/hpos-admin-client/hpos-admin-client.py
@@ -46,6 +46,30 @@ def put_settings(ctx, k, v):
     assert res.status_code == requests.codes.ok
 
 
+@cli.command(help='Get state of an HPOS feature')
+@click.argument('profile')
+@click.argument('feature')
+@click.pass_context
+def get_feature_state(ctx, profile, feature):
+    print(request(ctx, 'GET', f'/profiles/{profile}/features/{feature}').json())
+
+
+@cli.command(help='Enable an HPOS feature')
+@click.argument('profile')
+@click.argument('feature')
+@click.pass_context
+def enable_feature(ctx, profile, feature):
+    print(request(ctx, 'PUT', f'/profiles/{profile}/features/{feature}').json())
+
+
+@cli.command(help='Disable an HPOS feature')
+@click.argument('profile')
+@click.argument('feature')
+@click.pass_context
+def disable_feature(ctx, profile, feature):
+    print(request(ctx, 'DELETE', f'/profiles/{profile}/features/{feature}').json())
+
+
 @cli.command(help='Get HoloPortOS status data')
 @click.pass_context
 def get_status(ctx):

--- a/overlays/holo-nixpkgs/hpos-admin/default.nix
+++ b/overlays/holo-nixpkgs/hpos-admin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, python3, hpos-config-is-valid, zerotierone, hpos-reset }:
+{ stdenv, makeWrapper, python3, hpos-config-is-valid, hpos-reset, nix, zerotierone }:
 
 with stdenv.lib;
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildCommand = ''
     makeWrapper ${python3}/bin/python3 $out/bin/${name} \
       --add-flags ${./hpos-admin.py} \
-      --prefix PATH : ${makeBinPath [ hpos-config-is-valid zerotierone hpos-reset ]}
+      --prefix PATH : ${makeBinPath [ hpos-config-is-valid hpos-reset nix zerotierone ]}
   '';
 
   meta.platforms = platforms.linux;

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -57,6 +57,7 @@ def cas_hash(data):
 def dig(dictionary, keys, default = None):
     return reduce(lambda acc, key: acc.get(key) if acc else None, keys, dictionary) or default
 
+
 @app.route('/config', methods=['GET'])
 def get_settings():
     return jsonify(get_state_data()['v1']['settings'])
@@ -103,7 +104,8 @@ def read_profiles():
 
 
 def write_profiles(profiles):
-    toml.dump(profiles, PROFILES_TOML_PATH)
+    with open(PROFILES_TOML_PATH, 'w') as f:
+        f.write(toml.dumps(profiles))
 
 
 def set_feature_state(profile, feature, enable = True):

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -4,6 +4,7 @@ from functools import reduce
 from gevent import subprocess, pywsgi, queue, socket, spawn, lock
 from gevent.subprocess import CalledProcessError
 from hashlib import sha512
+from pathlib import Path
 from tempfile import mkstemp
 import json
 import os
@@ -89,7 +90,10 @@ def put_settings():
 
 
 def read_profiles():
-    return toml.load(PROFILES_TOML_PATH)
+    if Path(PROFILES_TOML_PATH).is_file():
+        return toml.load(PROFILES_TOML_PATH)
+    else:
+        return {}
 
 
 def write_profiles(profiles):

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -128,7 +128,7 @@ def get_profiles():
 def get_feature_state(profile, feature):
     profiles = read_profiles()
     keys = [profile, 'features', feature, 'enable']
-    enabled = reduce(lambda d, key: d.get(key) if d else None, keys, profiles)
+    enabled = reduce(lambda d, key: d.get(key) if d else None, keys, profiles) or False
     return jsonify({
         'enabled': enabled
     })

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -29,8 +29,12 @@ def rebuild_worker():
         subprocess.run(cmd)
 
 
-def rebuild(priority, args):
-    rebuild_queue.put((priority, ['nixos-rebuild', 'switch'] + args))
+def rebuild(priority):
+    rebuild_queue.put((priority, ['systemctl', 'start', 'nixos-rebuild.service']))
+
+
+def rebuild_upgrade(priority):
+    rebuild_queue.put((priority, ['systemctl', 'start', 'holo-nixpkgs-auto-upgrade.service']))
 
 
 def get_state_path():
@@ -77,7 +81,7 @@ def put_settings():
         except CalledProcessError:
             return '', 400
         replace_file_contents(get_state_path(), state_json)
-    rebuild(priority=5, args=[])
+    rebuild(priority=5)
     return '', 200
 
 
@@ -236,7 +240,7 @@ def status():
 
 @app.route('/upgrade', methods=['POST'])
 def upgrade():
-    rebuild(priority=1, args=['--upgrade'])
+    rebuild_upgrade(priority=1)
     return '', 200
 
 

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -82,7 +82,8 @@ def put_settings():
         except CalledProcessError:
             return '', 400
         replace_file_contents(get_state_path(), state_json)
-    rebuild(priority=5)
+    # FIXME: see next FIXME
+    # rebuild(priority=5)
     return '', 200
 
 
@@ -244,8 +245,9 @@ def status():
 
 @app.route('/upgrade', methods=['POST'])
 def upgrade():
-    rebuild_upgrade(priority=1)
-    return '', 200
+    # FIXME: calling nixos-rebuild fails
+    # rebuild_upgrade(priority=1)
+    return '', 503 # service unavailable
 
 
 @app.route('/reset', methods=['POST'])

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -12,6 +12,10 @@ import requests
 import asyncio
 import websockets
 
+
+PROFILES_TOML_PATH = '/etc/nixos/hpos-admin-features.toml'
+
+
 app = Flask(__name__)
 rebuild_queue = queue.PriorityQueue()
 state_lock = lock.Semaphore()

--- a/tests/hpos-admin/default.nix
+++ b/tests/hpos-admin/default.nix
@@ -81,6 +81,13 @@ makeTest {
     die "unexpected_hosted_happs_number_instances" if (index($actual_hosted_happs, $expected_number_instances) == -1);
     die "unexpected_hosted_happs_stats" if (index($actual_hosted_happs, $expected_stats) == -1);
 
+    my $ssh_enabled = $machine->succeed("hpos-admin-client --url=http://localhost get-feature-state development ssh");
+    die "ssh should not be enabled by default" unless index($ssh_enabled, "false") != -1;
+
+    $machine->succeed("hpos-admin-client --url=http://localhost enable-feature development ssh");
+    $ssh_enabled = $machine->succeed("hpos-admin-client --url=http://localhost get-feature-state development ssh");
+    die "ssh should be enabled after calling enable-feature" unless index($ssh_enabled, "true") != -1;
+
     $machine->shutdown;
 
   '';


### PR DESCRIPTION
Routes added to HP Admin:
- `GET /profiles`: get the whole TOML file generated by HP Admin
- `GET /profiles/<profile>/features/<feature>`: check if a feature is enabled
  - returns `{"enabled": bool}`
- `PUT /profiles/<profile>/features/<feature>`: enable a feature
- `DELETE /profiles/<profile>/features/<feature>`: disable a feature