### PR TITLE
overlays/hpos-admin: Change upgrade endpoint mechanism

### DIFF
--- a/overlays/holo-nixpkgs/hpos-admin-client/hpos-admin-client.py
+++ b/overlays/holo-nixpkgs/hpos-admin-client/hpos-admin-client.py
@@ -66,5 +66,15 @@ def factory_reset(ctx):
         print("Failed to reset device")
 
 
+@cli.command(help='Initiate a software upgrade')
+@click.pass_context
+def start_upgrade(ctx):
+    res = request(ctx, 'POST', '/upgrade')
+    if res.status_code == 200:
+        print("Upgrade successful")
+    if res.status_code == 500:
+        print("Failed to upgrade device")
+
+
 if __name__ == '__main__':
     cli(obj={})

--- a/overlays/holo-nixpkgs/hpos-admin/default.nix
+++ b/overlays/holo-nixpkgs/hpos-admin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, python3, hpos-config-is-valid, zerotierone, hpos-reset }:
+{ stdenv, makeWrapper, python3, hpos-config-is-valid, zerotierone, hpos-update-cli, hpos-reset }:
 
 with stdenv.lib;
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildCommand = ''
     makeWrapper ${python3}/bin/python3 $out/bin/${name} \
       --add-flags ${./hpos-admin.py} \
-      --prefix PATH : ${makeBinPath [ hpos-config-is-valid zerotierone hpos-reset ]}
+      --prefix PATH : ${makeBinPath [ hpos-config-is-valid zerotierone hpos-reset hpos-update-cli ]}
   '';
 
   meta.platforms = platforms.linux;

--- a/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
+++ b/overlays/holo-nixpkgs/hpos-admin/hpos-admin.py
@@ -23,7 +23,7 @@ def rebuild_worker():
 
 
 def rebuild(priority, args):
-    rebuild_queue.put((priority, ['nixos-rebuild', 'switch'] + args))
+    rebuild_queue.put((priority, ['hpos-update'] + args))
 
 
 def get_state_path():
@@ -137,6 +137,7 @@ def zerotier_info():
 
 @app.route('/status', methods=['GET'])
 def status():
+    print("test")
     return jsonify({
         'holo_nixpkgs':{
             'channel': {
@@ -153,8 +154,12 @@ def status():
 
 @app.route('/upgrade', methods=['POST'])
 def upgrade():
-    rebuild(priority=1, args=['--upgrade'])
-    return '', 200
+    print('Calling upgrade route')
+    try:
+        rebuild(priority=1, args=[hydra_channel()])
+        return '', 200
+    except CalledProcessError:
+        return '', 500
 
 
 @app.route('/reset', methods=['POST'])

--- a/overlays/holo-nixpkgs/hpos-update/default.nix
+++ b/overlays/holo-nixpkgs/hpos-update/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, gitignoreSource, jq, perl, git }:
+{ stdenv, makeWrapper, gitignoreSource, curl, jq, git, nix, perl }:
 
 with stdenv.lib;
 
@@ -13,7 +13,7 @@ with stdenv.lib;
     installPhase = ''
       install -Dm 755 hpos-update.sh $out/bin/${name}
       wrapProgram $out/bin/${name} \
-      --prefix PATH : ${makeBinPath [ jq git perl ]}
+      --prefix PATH : ${makeBinPath [ curl jq git nix perl ]}
     '';
 
     meta.platforms = platforms.linux;

--- a/overlays/holo-nixpkgs/hpos-update/hpos-update.sh
+++ b/overlays/holo-nixpkgs/hpos-update/hpos-update.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Simple shell script for switching nix channel and running a manual update
-# type bump-dna for help
+# run hpos-update for help
 ##
 
 set -e


### PR DESCRIPTION
Changing hpos-admin /upgrade endpoint to use `hpos-update` rather than `nixos-rebuild switch` so that the new local revision is saved in .nix-revision file.