### PR TITLE
HPOS update handles cache result scenario

### DIFF
--- a/overlays/holo-nixpkgs/hpos-update/hpos-update.sh
+++ b/overlays/holo-nixpkgs/hpos-update/hpos-update.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Simple shell script for switching nix channel and running a manual update
-# type bump-dna for help
+# type hpos-update for help
 ##
 
 set -e
@@ -15,8 +15,14 @@ echo 'Switching HoloPort to channel:' $1
 nix-channel --add https://hydra.holo.host/channel/custom/holo-nixpkgs/$1/holo-nixpkgs
 nix-channel --update
 
-curl -L -H Content-Type:application/json https://hydra.holo.host/jobset/holo-nixpkgs/$1/latest-eval | jq -r '.jobsetevalinputs | ."holo-nixpkgs" | .revision' | perl -pe 'chomp' > /root/.nix-revision
-nixos-rebuild switch
-echo 'Successfully updated HoloPort to channel:' $1
+update = $(nixos-rebuild switch) 
+
+if echo $update | grep -q "using cached result"; then
+    echo "Unable to update and using cached result"
+    exit 1
+else
+    curl -L -H Content-Type:application/json https://hydra.holo.host/jobset/holo-nixpkgs/$1/latest-eval | jq -r '.jobsetevalinputs | ."holo-nixpkgs" | .revision' | perl -pe 'chomp' > /root/.nix-revision
+    echo 'Successfully updated HoloPort to channel:' $1
+fi
 
 exit 0

--- a/overlays/holo-nixpkgs/hpos-update/hpos-update.sh
+++ b/overlays/holo-nixpkgs/hpos-update/hpos-update.sh
@@ -15,7 +15,7 @@ echo 'Switching HoloPort to channel:' $1
 nix-channel --add https://hydra.holo.host/channel/custom/holo-nixpkgs/$1/holo-nixpkgs
 nix-channel --update
 
-update = $(nixos-rebuild switch) 
+update=$(nixos-rebuild switch 2>&1)
 
 if echo $update | grep -q "using cached result"; then
     echo "Unable to update and using cached result"


### PR DESCRIPTION
1) Confirmed that this "does no harm" - `hpos-update` works as usual in the success case
2) Confirmed that this fixes standard errors leading to false positive. When update fails, `get-status` will show the correct (pre-update) holo-nixpkgs hash
3) Confirmed that script captures the correct output to `grep` for cached results
4) CAN NOT reproduce actual cached result error