### PR TITLE
Rc2 hotfixes

### DIFF
--- a/nixpkgs/src/default.nix
+++ b/nixpkgs/src/default.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/c156dc70be7db130fd2cf33f9f0d98655a40c61b.tar.gz";
-  sha256 = "0jqvlnqfgkfd9prh5hry0rf1qmy3i2fa0rn0dlpn8imfxz9hp285";
+  url = "https://github.com/NixOS/nixpkgs/archive/be60a5d964592cf17a2e128b99368ee34aa5f0b3.tar.gz";
+  sha256 = "0kpgjnpmdh0mwrdhyzz3l1j2qi0mggh78z99wh3wkcppcspv3gvw";
 }

--- a/overlays/holo-nixpkgs/hpos-update/hpos-update.sh
+++ b/overlays/holo-nixpkgs/hpos-update/hpos-update.sh
@@ -15,7 +15,7 @@ echo 'Switching HoloPort to channel:' $1
 nix-channel --add https://hydra.holo.host/channel/custom/holo-nixpkgs/$1/holo-nixpkgs
 nix-channel --update
 
-update=$(nixos-rebuild switch 2>&1)
+update=$(nixos-rebuild switch --verbose 2>&1)
 
 if echo $update | grep -q "using cached result"; then
     echo "Unable to update and using cached result"


### PR DESCRIPTION
- Add verbose flag to hpos-update
- Bump for upstream lv2m bug fix (causes confusing false error messages)