### PR TITLE
treewide: add hc-state command to HPOS

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -38,7 +38,7 @@ let
   };
 in
 
-{
+rec {
   yarn2nix = yarn2nix-moretea;
 
   inherit (callPackage ./aorura {}) aorura;
@@ -123,6 +123,12 @@ in
   };
 
   extlinux-conf-builder = callPackage ./extlinux-conf-builder {};
+
+  hc-state = writeShellScriptBin "hc-state" ''
+    ${nodejs}/bin/node ${hc-state-node}/main.js "$@"
+  '';
+
+  inherit (callPackage ./hc-state-node {}) hc-state-node; 
 
   holo-cli = callPackage ./holo-cli {};
 

--- a/overlays/holo-nixpkgs/hc-state-node/default.nix
+++ b/overlays/holo-nixpkgs/hc-state-node/default.nix
@@ -1,0 +1,34 @@
+{ stdenv,  nodejs, npmToNix, fetchFromGitHub }:
+
+{
+  hc-state-node = stdenv.mkDerivation rec {
+    name = "hc-state-node";
+
+    src = fetchFromGitHub {
+      owner = "Holochain";
+      repo = "hc-state-cli-node";
+      rev = "318f7eea2899c876bf1e664d4e6288e5ac8d100f";
+      sha256 = "0ab0a15hmr4alxpi016v4scm3rzznappkpvwbar9wgb07j0x0xry";
+    };
+
+    buildInputs = [ nodejs ];
+
+    preConfigure = ''
+      cp -r ${npmToNix { src = "${src}/"; }} node_modules
+      chmod -R +w node_modules
+      chmod +x node_modules/.bin/webpack
+      patchShebangs node_modules
+    '';
+
+    buildPhase = ''
+      npm run build
+    '';
+
+    installPhase = ''
+      cp -r dist/ $out
+    '';
+
+    doCheck = false;
+    meta.platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -41,7 +41,7 @@ in
   # REVIEW: `true` breaks gtk+ builds (cairo dependency)
   environment.noXlibs = false;
 
-  environment.systemPackages = [ hpos-reset hpos-admin-client hpos-update-cli git ];
+  environment.systemPackages = [ hc-state hpos-reset hpos-admin-client hpos-update-cli git ];
 
   networking.firewall.allowedTCPPorts = [ 443 ];
 


### PR DESCRIPTION
Adds `hc-state` CLI to HPOS (type `hc-state` for more info)