### PR TITLE
elemental-chat fixes by bumping holochain

### DIFF
--- a/overlays/holo-nixpkgs/hc-state-node/default.nix
+++ b/overlays/holo-nixpkgs/hc-state-node/default.nix
@@ -7,8 +7,8 @@
     src = fetchFromGitHub {
       owner = "Holochain";
       repo = "hc-state-cli-node";
-      rev = "ffee6a4fe45c4eacd5ebe7c95f18a75331b4a093";
-      sha256 = "07z02wkg6qpi06qm4dlh6m2d84g35dphpvhbbr6vr1p6kbxzrv8l";
+      rev = "0da0c0954e2314d507dce0bcfe6d30ff97321a62";
+      sha256 = "1p8mbcna6ijhwxmjggqr2w7nqzm5lgslxi2a8lr0nqp9wxclr955";
     };
 
     buildInputs = [ nodejs ];

--- a/overlays/holo-nixpkgs/hc-state-node/default.nix
+++ b/overlays/holo-nixpkgs/hc-state-node/default.nix
@@ -7,8 +7,8 @@
     src = fetchFromGitHub {
       owner = "Holochain";
       repo = "hc-state-cli-node";
-      rev = "1d616afa67181283bb9bd6ba27a297c2c97665d7";
-      sha256 = "0y8q8j846z5bjh491xal2pyqzdbr9r2v54dzc5bzwh52dp8qwlmf";
+      rev = "ffee6a4fe45c4eacd5ebe7c95f18a75331b4a093";
+      sha256 = "07z02wkg6qpi06qm4dlh6m2d84g35dphpvhbbr6vr1p6kbxzrv8l";
     };
 
     buildInputs = [ nodejs ];

--- a/overlays/holo-nixpkgs/holochain/default.nix
+++ b/overlays/holo-nixpkgs/holochain/default.nix
@@ -6,11 +6,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "holochain";
-    rev = "ddda96773b3e97f658ed46f2400ff8d0183be3fd";
-    sha256 = "10hdq77klxw50n3yp5zpavwi1kx9ld19lf6vz2m46zk9dm8gl5qq";
+    rev = "2c12ea38aaa659e8fb44d8d4d08abf4816491c6f";
+    sha256 = "1g44gvldf8mifxkjmxag8zs767nlm2qag8n9l4b95rcjn56injvx";
   };
 
-  cargoSha256 = "1nyqfcf8y22v1shcniv4pxi3kiqgqqxp2gn3l3wqfw5pnh0ch84r";
+  cargoSha256 = "1jpkvcdwcrijzka1jjlkwy1xxsr0p9c2w3ja42vkvxk3xzp9wz8s";
 
   nativeBuildInputs = [ perl pkgconfig ];
 

--- a/overlays/holo-nixpkgs/hpos-holochain-api/package-lock.json
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@holochain/conductor-api": {
-      "version": "0.0.1-dev.10",
-      "resolved": "https://registry.npmjs.org/@holochain/conductor-api/-/conductor-api-0.0.1-dev.10.tgz",
-      "integrity": "sha512-neqv2q7lZtRNcoeJ9oUXZ4DDM5x3R5WOj/izH4EhHep1xGpze+wk9Zb8Iz/BR+vrw8TVf8prBpdhPAeJbJRCFg==",
+      "version": "0.0.1-dev.12",
+      "resolved": "https://registry.npmjs.org/@holochain/conductor-api/-/conductor-api-0.0.1-dev.12.tgz",
+      "integrity": "sha512-vr06vEFnoYvoJ9zgNaANU/DE04633OK3cXWAdzOGfpZMoeIXXniY/bJx9kgXXJiA+LW5hSCAFDJEBaOV59j2eg==",
       "requires": {
         "@msgpack/msgpack": "^2.1.0",
         "@types/ws": "^7.2.4",
@@ -990,9 +990,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nanoid": {
-      "version": "3.1.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.16.tgz",
-      "integrity": "sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w=="
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.18.tgz",
+      "integrity": "sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA=="
     },
     "negotiator": {
       "version": "0.6.2",

--- a/overlays/holo-nixpkgs/hpos-holochain-api/package.json
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/package.json
@@ -10,7 +10,7 @@
   "author": "robbie.carlton@holo.host",
   "license": "ISC",
   "dependencies": {
-    "@holochain/conductor-api": "0.0.1-dev.10",
+    "@holochain/conductor-api": "0.0.1-dev.12",
     "express": "^4.17.1",
     "yargs": "^16.1.0"
   },

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
@@ -19,7 +19,7 @@ const UNIX_SOCKET = '/run/hpos-holochain-api/hpos-holochain-api.sock'
 app.get('/hosted_happs', async (_, res) => {
   const appWebsocket = await AppWebsocket.connect(`ws://localhost:${argv.appPort}`)
 
-  const appInfo = appWebsocket.appInfo({ app_id: argv.appId })
+  const appInfo = appWebsocket.appInfo({ installed_app_id: argv.appId })
 
   if (!appInfo) {
     throw new Error(`Couldn't find Holo Hosting App with id ${argv.appId}`)

--- a/overlays/holo-nixpkgs/lair-keystore/default.nix
+++ b/overlays/holo-nixpkgs/lair-keystore/default.nix
@@ -6,11 +6,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "lair";
-    rev = "a8d4e972c5e674b07f34f8f51eb582266e1ad1db";
-    sha256 = "01yx7awai530m1s9vgdsj6b79xqqj30c6z55jvhpaqzl45cmj3aw";
+    rev = "7718ef2bf1386b7719a12d506b0c50e2240d162b";
+    sha256 = "01nvaz718m7r41fs3yyw2l8mswnhn6r3kqy9v6hdw8iinkg0x9qv";
   };
 
-  cargoSha256 = "0zfx8hc55hxa4v86xwx5w7s34y1ayx5czmpa9kdvc870bzwfnwcx";
+  cargoSha256 = "07mf5r1yw2b2dimha6nskf1qrvyncjb5g97ilm68209h8qj0i1fy";
 
   doCheck = false;
 }

--- a/overlays/holo-nixpkgs/lair-keystore/default.nix
+++ b/overlays/holo-nixpkgs/lair-keystore/default.nix
@@ -6,11 +6,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "lair";
-    rev = "7718ef2bf1386b7719a12d506b0c50e2240d162b";
-    sha256 = "01nvaz718m7r41fs3yyw2l8mswnhn6r3kqy9v6hdw8iinkg0x9qv";
+    rev = "7b5f886dd7c9060175f20c05f80d0a298cce34f0";
+    sha256 = "1rigd5q69pgbh7rfzfsaxba83x0g1amrj6yy3xf66kgly8mxzhl8";
   };
 
-  cargoSha256 = "07mf5r1yw2b2dimha6nskf1qrvyncjb5g97ilm68209h8qj0i1fy";
+  cargoSha256 = "1c2380251nzhzs7cd6mgrjpyh52614i7ca01c5kl6cgqz41k80ii";
 
   doCheck = false;
 }

--- a/overlays/holo-nixpkgs/self-hosted-happs/default.nix
+++ b/overlays/holo-nixpkgs/self-hosted-happs/default.nix
@@ -6,8 +6,8 @@
     src = fetchFromGitHub {
       owner = "holo-host";
       repo = "self-hosted-happs-node";
-      rev = "4b1a3725fb2d0f3b6b66b0980589d63584872e6f";
-      sha256 = "102prnw57fjw5rnafn5az6cw90ywlqk86gpbkwfxziji2q7xsla3";
+      rev = "81fcefc12e878a08855f9659a2126b3915fd7dc0";
+      sha256 = "1rl49dvz5hg8xj2h4q3x186wdl36y3h86nza6s60b09d9ns6wnyl";
     };
 
     buildInputs = [ nodejs ];

--- a/overlays/holo-nixpkgs/self-hosted-happs/default.nix
+++ b/overlays/holo-nixpkgs/self-hosted-happs/default.nix
@@ -6,8 +6,8 @@
     src = fetchFromGitHub {
       owner = "holo-host";
       repo = "self-hosted-happs-node";
-      rev = "81fcefc12e878a08855f9659a2126b3915fd7dc0";
-      sha256 = "1rl49dvz5hg8xj2h4q3x186wdl36y3h86nza6s60b09d9ns6wnyl";
+      rev = "f136fdd0d7a033d99c3f59033daa77062ede991a";
+      sha256 = "1pv9vcnqwbczk918mh334lz03pq1g6dvlypsl6870csrbygvmzgl";
     };
 
     buildInputs = [ nodejs ];

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -199,9 +199,9 @@ in
     default-list = [
       {
         app_id = "elemental-chat";
-        version = "1";
-        ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/alpha0/elemental-chat.zip";
-        dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha0/elemental-chat.dna.gz";
+        version = "alpha1";
+        ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/alpha1/elemental-chat.zip ";
+        dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha1/elemental-chat.dna.gz";
       }
     ];
   };


### PR DESCRIPTION
- bumps holochain and all its dependencies
- currently failing to build are holochain and lair. see: 47d973ec3d394cf11f71e603eb42ac162e350af3