### PR TITLE
checkinterval from 10s -> 60s

### DIFF
--- a/profiles/logical/holo/hydra/master/specs/holo-envoy.json
+++ b/profiles/logical/holo/hydra/master/specs/holo-envoy.json
@@ -1,5 +1,5 @@
 {
-  "checkinterval": 10,
+  "checkinterval": 60,
   "emailoverride": "",
   "enabled": true,
   "enableemail": false,


### PR DESCRIPTION
Too frequent checks for changes are triggering a flood of evaluations on server. This is consuming significant amount of CPU. I am switching from 10s interval to 60s interval.