### PR TITLE
Elemental Chat Updates and Fixes

### DIFF
--- a/overlays/holo-nixpkgs/hc-state-node/default.nix
+++ b/overlays/holo-nixpkgs/hc-state-node/default.nix
@@ -7,8 +7,8 @@
     src = fetchFromGitHub {
       owner = "Holochain";
       repo = "hc-state-cli-node";
-      rev = "0da0c0954e2314d507dce0bcfe6d30ff97321a62";
-      sha256 = "1p8mbcna6ijhwxmjggqr2w7nqzm5lgslxi2a8lr0nqp9wxclr955";
+      rev = "8e86e5827093c7a0682fc1eaf7e348758a08a3f0";
+      sha256 = "006b6hyrd33jafg4ix0k4q8q7qp854yn8gmxqs8nmpq9kdpg5h0s";
     };
 
     buildInputs = [ nodejs ];

--- a/overlays/holo-nixpkgs/holochain/default.nix
+++ b/overlays/holo-nixpkgs/holochain/default.nix
@@ -6,11 +6,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "holochain";
-    rev = "feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb";
-    sha256 = "067r3p16jlrg7hwlm8jq7is50hmc7ylnl2wyxmws274yzls4g1sg";
+    rev = "cf4e72416e5afbf29b86d66a3d47ab2f9f6a65d2";
+    sha256 = "14h83k5wm7z17vzj23s291kab62jmxysn9hp9wnifnbcmln3h5lh";
   };
 
-  cargoSha256 = "1dp6gccpshz6h8q0r439gkxzh96s1y2s7aykadfzzjwlaahdm1kv";
+  cargoSha256 = "01bfmvfxj13vkj1zw79j212ymimk7sh2p6pm059aipzj816dmnrx";
 
   nativeBuildInputs = [ perl pkgconfig ];
 

--- a/overlays/holo-nixpkgs/holochain/default.nix
+++ b/overlays/holo-nixpkgs/holochain/default.nix
@@ -6,11 +6,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "holochain";
-    rev = "2c12ea38aaa659e8fb44d8d4d08abf4816491c6f";
-    sha256 = "1g44gvldf8mifxkjmxag8zs767nlm2qag8n9l4b95rcjn56injvx";
+    rev = "feb6efd6ff25414a0bc5ab9ab8288d4cf188e8bb";
+    sha256 = "067r3p16jlrg7hwlm8jq7is50hmc7ylnl2wyxmws274yzls4g1sg";
   };
 
-  cargoSha256 = "1jpkvcdwcrijzka1jjlkwy1xxsr0p9c2w3ja42vkvxk3xzp9wz8s";
+  cargoSha256 = "1dp6gccpshz6h8q0r439gkxzh96s1y2s7aykadfzzjwlaahdm1kv";
 
   nativeBuildInputs = [ perl pkgconfig ];
 

--- a/overlays/holo-nixpkgs/holochain/default.nix
+++ b/overlays/holo-nixpkgs/holochain/default.nix
@@ -6,11 +6,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "holochain";
-    rev = "bc1e9b98cc30a0dac8bf8d9a3eee5cc3c5e4e218";
-    sha256 = "0991y090yq2i8q7knzn7ga4iss34qfa2rgd732vhv8pdin33qmv4";
+    rev = "bdd2578a93f81e13d425bd3ed8a6cdc3356f8e1d";
+    sha256 = "1vy1mkbm9hnxxd3j2hpfrjscxwrxj3w38m9cfigpa0vsls2l2x9k";
   };
 
-  cargoSha256 = "01bfmvfxj13vkj1zw79j212ymimk7sh2p6pm059aipzj816dmnrx";
+  cargoSha256 = "0crpxmxp7fq5xq8amls89jjcj0yxn8ijk1bm2v0h97jyb3rq8j6d";
 
   nativeBuildInputs = [ perl pkgconfig ];
 

--- a/overlays/holo-nixpkgs/holochain/default.nix
+++ b/overlays/holo-nixpkgs/holochain/default.nix
@@ -6,8 +6,8 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "holochain";
     repo = "holochain";
-    rev = "cf4e72416e5afbf29b86d66a3d47ab2f9f6a65d2";
-    sha256 = "14h83k5wm7z17vzj23s291kab62jmxysn9hp9wnifnbcmln3h5lh";
+    rev = "bc1e9b98cc30a0dac8bf8d9a3eee5cc3c5e4e218";
+    sha256 = "0991y090yq2i8q7knzn7ga4iss34qfa2rgd732vhv8pdin33qmv4";
   };
 
   cargoSha256 = "01bfmvfxj13vkj1zw79j212ymimk7sh2p6pm059aipzj816dmnrx";

--- a/overlays/holo-nixpkgs/self-hosted-happs/default.nix
+++ b/overlays/holo-nixpkgs/self-hosted-happs/default.nix
@@ -6,8 +6,8 @@
     src = fetchFromGitHub {
       owner = "holo-host";
       repo = "self-hosted-happs-node";
-      rev = "f9f86d5da80cc000b0861ff89023c0e3ade4ecce";
-      sha256 = "1hlplk7a8q60fid349dmx668i73q4xd7azidx8pafcjnby8x6x50";
+      rev = "c0a5bcecbb6034a1ae872094920f08e048f748cf";
+      sha256 = "0vfqxk0ry3wm7z6d9a3fz5wyqnbbi7ylwnxavj27zlwshkhp0h09";
     };
 
     buildInputs = [ nodejs ];

--- a/overlays/holo-nixpkgs/self-hosted-happs/default.nix
+++ b/overlays/holo-nixpkgs/self-hosted-happs/default.nix
@@ -6,8 +6,8 @@
     src = fetchFromGitHub {
       owner = "holo-host";
       repo = "self-hosted-happs-node";
-      rev = "f136fdd0d7a033d99c3f59033daa77062ede991a";
-      sha256 = "1pv9vcnqwbczk918mh334lz03pq1g6dvlypsl6870csrbygvmzgl";
+      rev = "f9f86d5da80cc000b0861ff89023c0e3ade4ecce";
+      sha256 = "1hlplk7a8q60fid349dmx668i73q4xd7azidx8pafcjnby8x6x50";
     };
 
     buildInputs = [ nodejs ];

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -199,9 +199,9 @@ in
     default-list = [
       {
         app_id = "elemental-chat";
-        version = "alpha3";
-          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha7/elemental-chat.zip ";
-          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha3/elemental-chat.dna.gz";
+        version = "alpha4";
+          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha8/elemental-chat.zip ";
+          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha4/elemental-chat.dna.gz";
       }
     ];
   };

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -200,8 +200,8 @@ in
       {
         app_id = "elemental-chat";
         version = "alpha1";
-        ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/alpha1/elemental-chat.zip ";
-        dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha1/elemental-chat.dna.gz";
+          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha3/elemental-chat.zip ";
+          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha1/elemental-chat.dna.gz";
       }
     ];
   };

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -199,9 +199,9 @@ in
     default-list = [
       {
         app_id = "elemental-chat";
-        version = "alpha2";
-          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha5/elemental-chat.zip ";
-          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha2/elemental-chat.dna.gz";
+        version = "alpha3";
+          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha6/elemental-chat.zip ";
+          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha3/elemental-chat.dna.gz";
       }
     ];
   };

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -200,7 +200,7 @@ in
       {
         app_id = "elemental-chat";
         version = "alpha3";
-          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha6/elemental-chat.zip ";
+          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha7/elemental-chat.zip ";
           dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha3/elemental-chat.dna.gz";
       }
     ];

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -200,7 +200,7 @@ in
       {
         app_id = "elemental-chat";
         version = "alpha5";
-          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha9/elemental-chat.zip ";
+          ui_url = "https://github.com/zo-el/temp/releases/download/0.0.4/elemental-chat.zip";
           dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha5/elemental-chat.dna.gz";
       }
     ];

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -199,9 +199,9 @@ in
     default-list = [
       {
         app_id = "elemental-chat";
-        version = "alpha4";
-          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha8/elemental-chat.zip ";
-          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha4/elemental-chat.dna.gz";
+        version = "alpha5";
+          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha9/elemental-chat.zip ";
+          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha5/elemental-chat.dna.gz";
       }
     ];
   };

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -199,9 +199,9 @@ in
     default-list = [
       {
         app_id = "elemental-chat";
-        version = "alpha1";
-          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha3/elemental-chat.zip ";
-          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha1/elemental-chat.dna.gz";
+        version = "alpha2";
+          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha5/elemental-chat.zip ";
+          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha2/elemental-chat.dna.gz";
       }
     ];
   };


### PR DESCRIPTION
This is a PR for being able to add fixes to EC (and possible holochain) for dev-testing and possible Service Ops testing

- [x] conductor re-connection resiliency in UI
- [x] a number of UI fixes including scroll-bars, ability to change agent handle, version numbers, and updates `conductor-api`
- [x] updates `self-hosted-happs-node` and `hc-state-node` for fixes in `conductor-api` (dev.13)