### PR TITLE
Switch nano kernel version to follow default NixOS version

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -146,9 +146,7 @@ rec {
     inherit (rust.packages.holochain-rsm) rustPlatform;
   };
 
-  holoport-nano-dtb = callPackage ./holoport-nano-dtb {
-    linux = linux_latest;
-  };
+  holoport-nano-dtb = callPackage ./holoport-nano-dtb {};
 
   inherit (callPackage ./host-console-ui {}) host-console-ui;
 
@@ -221,7 +219,7 @@ rec {
     }
   );
 
-  linuxPackages_latest = previous.linuxPackages_latest.extend (
+  linuxPackages = previous.linuxPackages.extend (
     self: super: {
       sun50i-a64-gpadc-iio = self.callPackage ./linux-packages/sun50i-a64-gpadc-iio {};
     }

--- a/profiles/physical/hpos/holoport-nano/default.nix
+++ b/profiles/physical/hpos/holoport-nano/default.nix
@@ -11,9 +11,6 @@
 
   boot.kernelModules = [ "sun50i-a64-gpadc-iio" ];
 
-  # TODO: remove once Linux 5.1.4 becomes stable
-  boot.kernelPackages = pkgs.linuxPackages_latest;
-
   boot.kernelParams = [
     "console=ttyS0,115200n8"
     "console=tty0"


### PR DESCRIPTION
Currently nano is set to follow latest kernel. This was done back when old kernel (v5.1) did not have good support for Allwinner A64. Current LTS 5.4 which x64 HoloPorts follow has good support.

This fixes #628 