### PR TITLE
[TK-06431] Build holochain without default features and bump Rust to 1.48.0; bump Holochain; expose Rust and Holochain expressions

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -141,10 +141,10 @@ rec {
   );
 
   # holochain RSM requires version of rust matching holonix, which is set under rust.packages.holochain-rsm
-  holochain = callPackage ./holochain {
+  inherit (callPackage ./holochain {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
     inherit (rust.packages.stable) rustPlatform;
-  };
+  }) mkHolochainBinary holochain;
 
   holoport-nano-dtb = callPackage ./holoport-nano-dtb {};
 

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -143,7 +143,7 @@ rec {
   # holochain RSM requires version of rust matching holonix, which is set under rust.packages.holochain-rsm
   holochain = callPackage ./holochain {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
-    inherit (rust.packages.holochain-rsm) rustPlatform;
+    inherit (rust.packages.stable) rustPlatform;
   };
 
   holoport-nano-dtb = callPackage ./holoport-nano-dtb {};
@@ -231,51 +231,49 @@ rec {
 
   nodejs = nodejs-12_x;
 
-  rust = previous.rust // {
+  rust = previous.rust // (let
+    targets = [
+      "aarch64-unknown-linux-musl"
+      "wasm32-unknown-unknown"
+      "x86_64-pc-windows-gnu"
+      "x86_64-unknown-linux-musl"
+    ];
+
+    rustNightly = (rustChannelOf {
+      channel = "nightly";
+      date = "2019-11-16";
+      sha256 = "17l8mll020zc0c629cypl5hhga4hns1nrafr7a62bhsp4hg9vswd";
+    }).rust.override { inherit targets; };
+
+    rustStable = (rustChannelOf {
+      channel = "1.48.0";
+      sha256 = "0b56h3gh577wv143ayp46fv832rlk8yrvm7zw1dfiivifsn7wfzg";
+    }).rust.override { inherit targets; };
+  in {
     packages = previous.rust.packages // {
       nightly = {
         rustPlatform = final.makeRustPlatform {
-          inherit (buildPackages.rust.packages.nightly) cargo rustc;
+          rustc = rustNightly;
+          cargo = rustNightly;
         };
 
-        cargo = final.rust.packages.nightly.rustc;
-        rustc = (
-          rustChannelOf {
-            channel = "nightly";
-            date = "2019-11-16";
-            sha256 = "17l8mll020zc0c629cypl5hhga4hns1nrafr7a62bhsp4hg9vswd";
-          }
-        ).rust.override {
-          targets = [
-            "aarch64-unknown-linux-musl"
-            "wasm32-unknown-unknown"
-            "x86_64-pc-windows-gnu"
-            "x86_64-unknown-linux-musl"
-          ];
-        };
+        inherit (final.rust.packages.nightly.rustPlatform) rust;
       };
-      holochain-rsm = {
+
+      stable = {
         rustPlatform = final.makeRustPlatform {
-          inherit (buildPackages.rust.packages.holochain-rsm) cargo rustc;
+          rustc = rustStable;
+          cargo = rustStable;
         };
 
-        cargo = final.rust.packages.holochain-rsm.rustc;
-        rustc = (
-          rustChannelOf {
-            channel = "1.48.0";
-            sha256 = "0b56h3gh577wv143ayp46fv832rlk8yrvm7zw1dfiivifsn7wfzg";
-          }
-        ).rust.override {
-          targets = [
-            "aarch64-unknown-linux-musl"
-            "wasm32-unknown-unknown"
-            "x86_64-pc-windows-gnu"
-            "x86_64-unknown-linux-musl"
-          ];
-        };
+        inherit (final.rust.packages.stable.rustPlatform) rust;
+      };
+
+      holochain-rsm = {
+        inherit (final.rust.packages.stable) rustPlatform;
       };
     };
-  };
+  });
 
   inherit (callPackage ./self-hosted-happs {}) self-hosted-happs-node;
 

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -140,7 +140,6 @@ rec {
     import "${holo-nixpkgs.path}/tests" { inherit pkgs; }
   );
 
-  # holochain RSM requires version of rust matching holonix, which is set under rust.packages.holochain-rsm
   inherit (callPackage ./holochain {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
     inherit (rust.packages.stable) rustPlatform;
@@ -209,9 +208,8 @@ rec {
     }
   );
 
-  # holochain RSM requires version of rust matching holonix, which is set under rust.packages.holochain-rsm
   lair-keystore = callPackage ./lair-keystore {
-    inherit (rust.packages.holochain-rsm) rustPlatform;
+    inherit (rust.packages.stable) rustPlatform;
   };
 
   libsodium = previous.libsodium.overrideAttrs (
@@ -267,10 +265,6 @@ rec {
         };
 
         inherit (final.rust.packages.stable.rustPlatform) rust;
-      };
-
-      holochain-rsm = {
-        inherit (final.rust.packages.stable) rustPlatform;
       };
     };
   });

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -126,7 +126,7 @@ rec {
     ${nodejs}/bin/node ${hc-state-node}/main.js "$@"
   '';
 
-  inherit (callPackage ./hc-state-node {}) hc-state-node; 
+  inherit (callPackage ./hc-state-node {}) hc-state-node;
 
   holo-cli = callPackage ./holo-cli {};
 

--- a/overlays/holo-nixpkgs/holochain/default.nix
+++ b/overlays/holo-nixpkgs/holochain/default.nix
@@ -10,12 +10,12 @@ rustPlatform.buildRustPackage {
     sha256 = "1xcg30wwnicmz8yaz8vgi0x7z0ygjq3kkdpzp9743swqik4c0g6z";
   };
 
+  cargoSha256 = "0c4fwzxnff46g8y247a6aqh805f195akn5nyp1xirsdrh3cjgalw";
+
   cargoBuildFlags = [
     "--manifest-path=crates/holochain/Cargo.toml"
     "--no-default-features"
   ];
-
-  cargoSha256 = "0c4fwzxnff46g8y247a6aqh805f195akn5nyp1xirsdrh3cjgalw";
 
   nativeBuildInputs = [ perl pkgconfig ];
 

--- a/overlays/holo-nixpkgs/holochain/default.nix
+++ b/overlays/holo-nixpkgs/holochain/default.nix
@@ -41,9 +41,10 @@ rec {
   ]));
 
   holochain = mkHolochainBinary {
-    rev = "2c12ea38aaa659e8fb44d8d4d08abf4816491c6f";
-    sha256 = "1g44gvldf8mifxkjmxag8zs767nlm2qag8n9l4b95rcjn56injvx";
-    cargoSha256 = "0f4vp2j9lm1y82kshyajfbkmzssidin6v85kap3v1hvqf09yvnq0";
+    version = "2020-12-17";
+    rev = "6bd822cf3378178b5600ab79d8560f04b5a5b837";
+    sha256 = "1xcg30wwnicmz8yaz8vgi0x7z0ygjq3kkdpzp9743swqik4c0g6z";
+    cargoSha256 = "12nsp4xwfy0sa1v5wa4r8lskwpn1h5kr23qg5dvjlb20maxrp5dc";
     crate = "holochain";
   };
 }

--- a/overlays/holo-nixpkgs/holochain/default.nix
+++ b/overlays/holo-nixpkgs/holochain/default.nix
@@ -1,31 +1,49 @@
-{ stdenv, rustPlatform, fetchFromGitHub, perl, CoreServices, Security, libsodium, openssl, pkgconfig }:
+{ stdenv, rustPlatform, fetchFromGitHub, perl, CoreServices, Security, libsodium, openssl, pkgconfig, lib, callPackage }:
 
-rustPlatform.buildRustPackage {
-  name = "holochain";
+rec {
+  mkHolochainBinary = {
+        rev
+      , sha256
+      , cargoSha256
+      , crate
+      , ... } @ overrides: rustPlatform.buildRustPackage (lib.attrsets.recursiveUpdate {
+    name = "holochain";
 
-  src = fetchFromGitHub {
-    owner = "holochain";
-    repo = "holochain";
-    rev = "6bd822cf3378178b5600ab79d8560f04b5a5b837";
-    sha256 = "1xcg30wwnicmz8yaz8vgi0x7z0ygjq3kkdpzp9743swqik4c0g6z";
+    src = fetchFromGitHub {
+      owner = "holochain";
+      repo = "holochain";
+      inherit rev sha256;
+    };
+
+    inherit cargoSha256;
+
+    cargoBuildFlags = [
+      "--no-default-features"
+      "--manifest-path=crates/${crate}/Cargo.toml"
+    ];
+
+    nativeBuildInputs = [ perl pkgconfig ];
+
+    buildInputs = [ openssl ] ++ stdenv.lib.optionals stdenv.isDarwin [
+      CoreServices
+      Security
+    ];
+
+    RUST_SODIUM_LIB_DIR = "${libsodium}/lib";
+    RUST_SODIUM_SHARED = "1";
+
+    doCheck = false;
+  } (builtins.removeAttrs overrides [
+    "rev"
+    "sha256"
+    "cargoSha256"
+    "crate"
+  ]));
+
+  holochain = mkHolochainBinary {
+    rev = "2c12ea38aaa659e8fb44d8d4d08abf4816491c6f";
+    sha256 = "1g44gvldf8mifxkjmxag8zs767nlm2qag8n9l4b95rcjn56injvx";
+    cargoSha256 = "0f4vp2j9lm1y82kshyajfbkmzssidin6v85kap3v1hvqf09yvnq0";
+    crate = "holochain";
   };
-
-  cargoSha256 = "0c4fwzxnff46g8y247a6aqh805f195akn5nyp1xirsdrh3cjgalw";
-
-  cargoBuildFlags = [
-    "--manifest-path=crates/holochain/Cargo.toml"
-    "--no-default-features"
-  ];
-
-  nativeBuildInputs = [ perl pkgconfig ];
-
-  buildInputs = [ openssl ] ++ stdenv.lib.optionals stdenv.isDarwin [
-    CoreServices
-    Security
-  ];
-
-  RUST_SODIUM_LIB_DIR = "${libsodium}/lib";
-  RUST_SODIUM_SHARED = "1";
-
-  doCheck = false;
 }


### PR DESCRIPTION
This change makes holo-nixpkgs viable to be used by holonix and potentially other consumers as a source for the holochain packages.

Changes made
- [x] Bump Rust to 1.48.0
- [x] Restructure Rust and Holochain expressions and expose them
- [x] Bump Holochain
- [x] Bump lair-keystore to the matching version @peeech 
- [x] Bump everything else needed to be in sync with Holochain @peeech 