### PR TITLE
DevTest: EC and configure-holochain updates

### DIFF
--- a/overlays/holo-nixpkgs/configure-holochain/default.nix
+++ b/overlays/holo-nixpkgs/configure-holochain/default.nix
@@ -7,8 +7,8 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hpos-configure-holochain";
-    rev = "3f8c72f33d6582ef6d2542fc0628ba5f6616bb08";
-    sha256 = "1bpj3z193c97cgv7snzz65r0g5ip05j8ryc0k2lxjdzfh98i7wlb";
+    rev = "0d9d6dca334e43179814b8a909ecf3fe26b50325";
+    sha256 = "1ggyl1wrf7g1k155xfyp5qv7mx17jh8lgq25pnl98qp95zk7yjpv";
   };
 
   cargoSha256 = "178bd64if1wajmlna2ws7687majwwc1gx7xl1dl8i0ss17mx2wj0";

--- a/overlays/holo-nixpkgs/configure-holochain/default.nix
+++ b/overlays/holo-nixpkgs/configure-holochain/default.nix
@@ -7,8 +7,8 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hpos-configure-holochain";
-    rev = "0d9d6dca334e43179814b8a909ecf3fe26b50325";
-    sha256 = "1ggyl1wrf7g1k155xfyp5qv7mx17jh8lgq25pnl98qp95zk7yjpv";
+    rev = "cfbd0ca7af6e9efc5ad2ef1d97a9b0b054fc52ba";
+    sha256 = "1aic7vwasfjz3crnjnf355jqpfi3s7yqsxb6rbn6xb1sgvz1578g";
   };
 
   cargoSha256 = "178bd64if1wajmlna2ws7687majwwc1gx7xl1dl8i0ss17mx2wj0";

--- a/overlays/holo-nixpkgs/configure-holochain/default.nix
+++ b/overlays/holo-nixpkgs/configure-holochain/default.nix
@@ -7,11 +7,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hpos-configure-holochain";
-    rev = "e52ac50acc31e7e8dcddab0ff0a8cbd90ae3d6b6";
-    sha256 = "10mk138y2hl5xgpl110yvspvrjcs5p341ixrn7avlziw3cp52fnf";
+    rev = "3f8c72f33d6582ef6d2542fc0628ba5f6616bb08";
+    sha256 = "1bpj3z193c97cgv7snzz65r0g5ip05j8ryc0k2lxjdzfh98i7wlb";
   };
 
-  cargoSha256 = "0cjx904pwa9vczr2gvp1ifshl1vkq4fxc0r9djl2mjzi8x4aa8ak";
+  cargoSha256 = "178bd64if1wajmlna2ws7687majwwc1gx7xl1dl8i0ss17mx2wj0";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ];

--- a/overlays/holo-nixpkgs/holochain/default.nix
+++ b/overlays/holo-nixpkgs/holochain/default.nix
@@ -2,10 +2,10 @@
 
 rec {
   mkHolochainBinary = {
-        version ? "2020-12-17"
-      , rev ? "5daac31fe21f5d10c192bbe208f0b11f8ee67d88"
-      , sha256 ? "1zv063ivgwajr0sidaccr4igy67ll87xnadnm3df6glcmqgy1b3h"
-      , cargoSha256 ? "0w0cn23y858q8jqq77nx5ax51hqan3n43rzzb4146k2f0430rjx6"
+      version ? "2021-01-18"
+      , rev ? "593ad31a019cc941ee306202908da8d2e61d4b64"
+      , sha256 ? "044ipimj6dsg03iniakinhr60lbryp52n3jfpb5gk77nx1zmq3zc"
+      , cargoSha256 ? "11p0lc9p9y4rs4xf4ca9h5glkdb41a252fqdmas8s0h36rw9bwkz"
       , crate
       , ... } @ overrides: rustPlatform.buildRustPackage (lib.attrsets.recursiveUpdate {
     name = "holochain";

--- a/overlays/holo-nixpkgs/holochain/default.nix
+++ b/overlays/holo-nixpkgs/holochain/default.nix
@@ -3,8 +3,8 @@
 rec {
   mkHolochainBinary = {
       version ? "2021-01-18"
-      , rev ? "593ad31a019cc941ee306202908da8d2e61d4b64"
-      , sha256 ? "044ipimj6dsg03iniakinhr60lbryp52n3jfpb5gk77nx1zmq3zc"
+      , rev ? "b3b5f0171d93249189ac84b81f3fd3dbaa7d2528"
+      , sha256 ? "10sjf09qxsrmnq3as8ar49zh1xlqzr7q08dg80rjhmz8mp1k8rp3"
       , cargoSha256 ? "11p0lc9p9y4rs4xf4ca9h5glkdb41a252fqdmas8s0h36rw9bwkz"
       , crate
       , ... } @ overrides: rustPlatform.buildRustPackage (lib.attrsets.recursiveUpdate {

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -205,7 +205,7 @@ in
       self_hosted_happs = [
         {
           app_id = "elemental-chat";
-          uuid = "00000000000001";
+          uuid = "0001";
           version = "alpha14";
           ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha20/elemental-chat.zip";
           dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha14/elemental-chat.dna.gz"; # this version mismatch is on purpose for hash alteration

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -205,9 +205,9 @@ in
       self_hosted_happs = [
         {
           app_id = "elemental-chat";
-          uuid = "0001";
+          uuid = "0002";
           version = "alpha14";
-          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha20/elemental-chat.zip";
+          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha20/elemental-chat-0002.zip";
           dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha14/elemental-chat.dna.gz"; # this version mismatch is on purpose for hash alteration
         }
       ];

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -205,9 +205,9 @@ in
       self_hosted_happs = [
         {
           app_id = "elemental-chat";
-          uuid = "0002";
+          uuid = "0001";
           version = "alpha14";
-          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha20/elemental-chat-0002.zip";
+          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha20/elemental-chat.zip";
           dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha14/elemental-chat.dna.gz"; # this version mismatch is on purpose for hash alteration
         }
       ];

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -205,9 +205,10 @@ in
       self_hosted_happs = [
         {
           app_id = "elemental-chat";
+          uuid = "00000000000001";
           version = "alpha14";
-          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha19/elemental-chat.zip";
-          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha13/elemental-chat.dna.gz"; # this version mismatch is on purpose for hash alteration
+          ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha20/elemental-chat.zip";
+          dna_url = "https://github.com/holochain/elemental-chat/releases/download/v0.0.1-alpha14/elemental-chat.dna.gz"; # this version mismatch is on purpose for hash alteration
         }
       ];
     };


### PR DESCRIPTION
- bumps holochain to latest version (includes gossip fixes and RegisterDna updates)
- uses hpos-configure-holochain with UUID
- uses elemental chat ui alpha20
- sets uuid for elemental chat so we have a different hash-space