### PR TITLE
Holochain restart timer hot fix

### DIFF
--- a/modules/services/holochain.nix
+++ b/modules/services/holochain.nix
@@ -55,7 +55,7 @@ in
       serviceConfig.Type = "oneshot";
 
       script = ''
-        /run/current-system/sw/bin/systemctl try-restart holochain.service
+        ${pkgs.systemd}/bin/systemctl try-restart holochain.service
       '';
 
       startAt = cfg.restart-interval;

--- a/modules/services/holochain.nix
+++ b/modules/services/holochain.nix
@@ -25,7 +25,7 @@ in
 
     restart-interval = mkOption {
       type = types.str;
-    }
+    };
   };
 
   config = mkIf (cfg.enable) {

--- a/modules/services/holochain.nix
+++ b/modules/services/holochain.nix
@@ -22,6 +22,10 @@ in
     working-directory = mkOption {
       type = types.path;
     };
+
+    restart-interval = mkOption {
+      type = types.str;
+    }
   };
 
   config = mkIf (cfg.enable) {
@@ -45,6 +49,16 @@ in
         ExecStart = "${cfg.package}/bin/holochain -c ${cfg.working-directory}/holochain-config.yaml";
         StateDirectory = "holochain-rsm";
       };
+    };
+
+    systemd.services.holochain-restarter = {
+      serviceConfig.Type = "oneshot";
+
+      script = ''
+        /run/current-system/sw/bin/systemctl try-restart holochain.service
+      '';
+
+      startAt = cfg.restart-interval;
     };
 
     users.users.holochain-rsm = {

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -168,6 +168,7 @@ in
 
   services.holochain = {
     enable = true;
+    restart-interval = "00/2:30"; # every 2 hours at 30 past
     working-directory = holochainWorkingDir;
     config = {
       environment_path = "${holochainWorkingDir}/databases";


### PR DESCRIPTION
Adds a 2 hour restart timer to holochain service, as a hacky stop gap to networking performance degradation.

Note: we will need to reduce this frequency with hosted happs due poor UX.