### PR TITLE
overlays: disable virtualbox VM build

### DIFF
--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -169,9 +169,9 @@ rec {
       meta.platforms = [ "x86_64-linux" ];
     };
 
-    virtualbox = (hpos.buildImage [ "${hpos.physical}/vm/virtualbox" ]) // {
-      meta.platforms = [ "x86_64-linux" ];
-    };
+    # virtualbox = (hpos.buildImage [ "${hpos.physical}/vm/virtualbox" ]) // {
+    #   meta.platforms = [ "x86_64-linux" ];
+    # };
   };
 
   hpos-admin-api = callPackage ./hpos-admin-api {


### PR DESCRIPTION
@peeech Moving disable VM to a separate PR so we can merge it in faster and keep PRs small