### PR TITLE
Add ability to run `hpos-shell` against selected hpos profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,16 @@ To begin the upgrade immediately, use the following command:
 
 ### QEMU
 
-If you have Nix installed, checkout the repo, enter `nix-shell` and then run
-`hpos-shell`. That will launch a HoloPortOS VM against current state of your
-local checkout, which is useful for iterative development.
+If you have Nix installed, checkout the repo, enter `nix-shell` and then
+`hpos-shell` is available to you. Usage:
+```
+hpos-shell <attr>
+
+starts HPOS VM against local checkout of given profile.
+```
+where `<attr>` is one of the attributes of `hpos` from overlays. If no value given defaults to `qemu`. For example `hpos-shell tests` will start HPOS VM with the profile defined as in `holo-nixpkgs.hpos.tests`.
+
+Very useful for iterative local development.
 
 ### VirtualBox
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ hpos-shell <attr>
 
 starts HPOS VM against local checkout of given profile.
 ```
-where `<attr>` is one of the attributes of `hpos` from overlays. If no value given defaults to `qemu`. For example `hpos-shell tests` will start HPOS VM with the profile defined as in `holo-nixpkgs.hpos.tests`.
+where `<attr>` is one of the attributes of `hpos` from overlays. If no value given defaults to `qemu`. For example `hpos-shell tests` will start HPOS VM with the profile defined as in `holo-nixpkgs.hpos.test`.
 
 Very useful for iterative local development.
 

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -171,6 +171,7 @@ rec {
 
     test = (buildImage [ "${hpos.physical}/vm/qemu" "${hpos.logical}/sandbox/test"]) // {
       meta.platforms = [ "x86_64-linux" ];
+    };
   };
 
   hpos-admin-api = callPackage ./hpos-admin-api {

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -169,9 +169,8 @@ rec {
       meta.platforms = [ "x86_64-linux" ];
     };
 
-    # virtualbox = (hpos.buildImage [ "${hpos.physical}/vm/virtualbox" ]) // {
-    #   meta.platforms = [ "x86_64-linux" ];
-    # };
+    test = (buildImage [ "${hpos.physical}/vm/qemu" "${hpos.logical}/sandbox/test"]) // {
+      meta.platforms = [ "x86_64-linux" ];
   };
 
   hpos-admin-api = callPackage ./hpos-admin-api {

--- a/shell.nix
+++ b/shell.nix
@@ -24,8 +24,9 @@ mkShell {
     }
 
     hpos-shell() {
-      [ -z $1 ] && $1="hpos.qemu"
-      drv=$(nix-build ${root} --attr $1 --no-out-link --show-trace \
+      local attr=$1
+      [ -z "$attr" ] && attr="hpos.qemu"
+      drv=$(nix-build ${root} --attr "$attr" --no-out-link --show-trace \
           --option extra-substituters "${builtins.concatStringsSep " " extraSubstitutors}" \
           --option trusted-public-keys  "${builtins.concatStringsSep " " trustedPublicKeys}" )
       [ -z "$drv" ] || "$drv/bin/run-hpos-vm"

--- a/shell.nix
+++ b/shell.nix
@@ -24,7 +24,8 @@ mkShell {
     }
 
     hpos-shell() {
-      drv=$(nix-build ${root} --attr hpos.qemu --no-out-link --show-trace \
+      [ -z $1 ] && $1="hpos.qemu"
+      drv=$(nix-build ${root} --attr $1 --no-out-link --show-trace \
           --option extra-substituters "${builtins.concatStringsSep " " extraSubstitutors}" \
           --option trusted-public-keys  "${builtins.concatStringsSep " " trustedPublicKeys}" )
       [ -z "$drv" ] || "$drv/bin/run-hpos-vm"

--- a/shell.nix
+++ b/shell.nix
@@ -25,8 +25,8 @@ mkShell {
 
     hpos-shell() {
       local attr=$1
-      [ -z "$attr" ] && attr="hpos.qemu"
-      drv=$(nix-build ${root} --attr "$attr" --no-out-link --show-trace \
+      [ -z "$attr" ] && attr="qemu"
+      drv=$(nix-build ${root} --attr "hpos.$attr" --no-out-link --show-trace \
           --option extra-substituters "${builtins.concatStringsSep " " extraSubstitutors}" \
           --option trusted-public-keys  "${builtins.concatStringsSep " " trustedPublicKeys}" )
       [ -z "$drv" ] || "$drv/bin/run-hpos-vm"


### PR DESCRIPTION
Mostly for tests (`hpos-shell test` will start a VM against test machine profile).

Requires Oleksi's work on test profiles to be merged.