### PR TITLE
Add fallback for host console history

### DIFF
--- a/overlays/holo-nixpkgs/host-console-ui/default.nix
+++ b/overlays/holo-nixpkgs/host-console-ui/default.nix
@@ -6,8 +6,8 @@
     src = fetchFromGitHub {
       owner = "holo-host";
       repo = "host-console-ui";
-      rev = "475f80fe3ef1214a704f5efeba2fc220a9729cc6";
-      sha256 = "0nfrkq2cj604yb35dy5cb4im4k0sz54m31n45xpkc0x3lrh0yzjg";
+      rev = "6e3815227b5ffc1cc4cff6537368a620ff8d328e";
+      sha256 = "0cz1hb3nxzxxi7nf0sr5cdnigqjnb9khd502xvmxy4nk2b4x4v67";
     };
 
     packageJSON = "${src}/package.json";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -87,6 +87,7 @@ in
       locations = {
         "/" = {
           alias = "${pkgs.host-console-ui}/";
+          try_files = $uri $uri/ /index.html;
           extraConfig = ''
             limit_req zone=zone1 burst=30;
           '';


### PR DESCRIPTION
Companion to a PR in host console (TBD).

Host console uses Vue router, so it "spoofs" endpoints like /dashboard. If the user does a browser refresh they will request /dashboard from nginx, which is a 404 error. This PR is to redirect it to the login page again.