### PR TITLE
Add tryFiles to nginx host console config to prevent refresh errors

### DIFF
--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -87,6 +87,9 @@ in
       locations = {
         "/" = {
           alias = "${pkgs.host-console-ui}/";
+          tryFiles = ''
+             $uri $uri/ /index.html
+           '';
           extraConfig = ''
             limit_req zone=zone1 burst=30;
           '';


### PR DESCRIPTION
Without this, when you are logged into host console and refresh the page you get a `404` error.

With this, you get re-directed to login again.

This follows this pattern:
https://router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations

Note at the bottom of the link it recommends setting a 404 redirect within the Vue Router itself, which I have not done (I tried but I got some weird `"*" invalid route` errors and it didn't seem worth the effort to debug.