### PR TITLE
Add a flashing orange state to highlight holochain connectivity issues

### DIFF
--- a/modules/services/hpos-led-manager.nix
+++ b/modules/services/hpos-led-manager.nix
@@ -33,7 +33,7 @@ in
     };
 
     systemd.services.hpos-led-manager = {
-      path = [ pkgs.zerotierone ];
+      path = [ pkgs.zerotierone pkgs.holochainAllBinariesWithDeps.hpos.kitsune-p2p-proxy ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/hpos-led-manager --device ${cfg.devicePath} --state ${cfg.statePath} --kitsune ${cfg.kitsuneAddress}";
         ExecStopPost = "${pkgs.aorura}/bin/aorura-cli ${cfg.devicePath} --set flash:blue";

--- a/modules/services/hpos-led-manager.nix
+++ b/modules/services/hpos-led-manager.nix
@@ -20,6 +20,10 @@ in
     statePath = mkOption {
       default = "/run/hpos-led-manager/state.json";
     };
+
+    kitsuneAddress = mkOption {
+      type = types.str;
+    };
   };
 
   config = mkIf cfg.enable {
@@ -31,7 +35,7 @@ in
     systemd.services.hpos-led-manager = {
       path = [ pkgs.zerotierone ];
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/hpos-led-manager --device ${cfg.devicePath} --state ${cfg.statePath}";
+        ExecStart = "${cfg.package}/bin/hpos-led-manager --device ${cfg.devicePath} --state ${cfg.statePath} --kitsune_address ${cfg.kitsuneAddress}";
         ExecStopPost = "${pkgs.aorura}/bin/aorura-cli ${cfg.devicePath} --set flash:blue";
         RuntimeDirectory = "hpos-led-manager";
       };

--- a/modules/services/hpos-led-manager.nix
+++ b/modules/services/hpos-led-manager.nix
@@ -35,7 +35,7 @@ in
     systemd.services.hpos-led-manager = {
       path = [ pkgs.zerotierone ];
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/hpos-led-manager --device ${cfg.devicePath} --state ${cfg.statePath} --kitsune_address ${cfg.kitsuneAddress}";
+        ExecStart = "${cfg.package}/bin/hpos-led-manager --device ${cfg.devicePath} --state ${cfg.statePath} --kitsune ${cfg.kitsuneAddress}";
         ExecStopPost = "${pkgs.aorura}/bin/aorura-cli ${cfg.devicePath} --set flash:blue";
         RuntimeDirectory = "hpos-led-manager";
       };

--- a/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
+++ b/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Fallible<()> {
             .args(&["--", &args.flag_kitsune])
             .output()
         {   
-            Ok(output) =>{ 
+            Ok(output) => { 
                 let output_string = String::from_utf8(output.stdout)?;
                 output_string.contains("tokio_task_count")
             },

--- a/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
+++ b/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
@@ -14,7 +14,7 @@ use std::process::Command;
 const POLLING_INTERVAL: u64 = 1;
 
 const USAGE: &'static str = "
-Usage: hpos-led-manager --device <path> --state <path> --kitsune_address <url>
+Usage: hpos-led-manager --device <path> --state <path> --kitsune <url>
        hpos-led-manager --help
 
 Manages AORURA LED.
@@ -22,14 +22,14 @@ Manages AORURA LED.
 Options:
   --device <path>  Path to AORURA device
   --state <path>   Path to state JSON file
-  --kitsune_address Kitsune proxy URL to check
+  --kitsune <url>  Kitsune proxy url to check
 ";
 
 #[derive(Debug, Deserialize)]
 struct Args {
     flag_device: PathBuf,
     flag_state: PathBuf,
-    kitsune_address: String
+    flag_kitsune: String
 }
 
 fn main() -> Fallible<()> {
@@ -55,7 +55,7 @@ fn main() -> Fallible<()> {
         };
         
         let conn_kitsune_proxy = match Command::new("proxy-cli")
-            .args(&["--", &args.kitsune_address])
+            .args(&["--", &args.flag_kitsune])
             .output()
         {   
             Ok(output) =>{ 
@@ -73,7 +73,7 @@ fn main() -> Fallible<()> {
         let state = match (conn_zerotier, hpos_config_found, conn_kitsune_proxy) {
             (false, _, _) => State::Flash(Color::Purple),
             (true, false, _) => State::Static(Color::Blue),
-            (true, true, false) => State::Static(Color::Orange),
+            (true, true, false) => State::Flash(Color::Orange),
             _ => State::Aurora,
         };
 

--- a/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
+++ b/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
@@ -9,11 +9,12 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::thread::sleep;
 use std::time::Duration;
+use std::process::Command;
 
 const POLLING_INTERVAL: u64 = 1;
 
 const USAGE: &'static str = "
-Usage: hpos-led-manager --device <path> --state <path>
+Usage: hpos-led-manager --device <path> --state <path> --kitsune_address <url>
        hpos-led-manager --help
 
 Manages AORURA LED.
@@ -21,12 +22,14 @@ Manages AORURA LED.
 Options:
   --device <path>  Path to AORURA device
   --state <path>   Path to state JSON file
+  --kitsune_address Kitsune proxy URL to check
 ";
 
 #[derive(Debug, Deserialize)]
 struct Args {
     flag_device: PathBuf,
     flag_state: PathBuf,
+    kitsune_address: String
 }
 
 fn main() -> Fallible<()> {
@@ -43,19 +46,34 @@ fn main() -> Fallible<()> {
 
     loop {
         let router_gateway_addrs = "router-gateway.holo.host:80".to_socket_addrs();
-        let online = match router_gateway_addrs {
+        let conn_zerotier = match router_gateway_addrs {
             Ok(mut addrs) => match addrs.next() {
                 Some(addr) => TcpStream::connect_timeout(&addr, Duration::new(1, 0)).is_ok(),
                 None => false,
             },
             Err(_) => false,
         };
+        
+        let conn_kitsune_proxy = match Command::new("proxy-cli")
+            .args(&["--", &args.kitsune_address])
+            .output()
+        {   
+            Ok(output) =>{ 
+                let output_string = String::from_utf8(output.stdout)?;
+                match output_string {
+                    _ if output_string.contains("tokio_task_count") => true,
+                    _ => false,
+                }
+            },
+            Err(_) => false,
+        };
 
         let hpos_config_found = Path::new("/run/hpos-init/hpos-config.json").exists();
 
-        let state = match (online, hpos_config_found) {
-            (false, _) => State::Flash(Color::Purple),
-            (true, false) => State::Static(Color::Blue),
+        let state = match (conn_zerotier, hpos_config_found, conn_kitsune_proxy) {
+            (false, _, _) => State::Flash(Color::Purple),
+            (true, false, _) => State::Static(Color::Blue),
+            (true, true, false) => State::Static(Color::Orange),
             _ => State::Aurora,
         };
 

--- a/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
+++ b/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
@@ -60,10 +60,7 @@ fn main() -> Fallible<()> {
         {   
             Ok(output) =>{ 
                 let output_string = String::from_utf8(output.stdout)?;
-                match output_string {
-                    _ if output_string.contains("tokio_task_count") => true,
-                    _ => false,
-                }
+                output_string.contains("tokio_task_count")
             },
             Err(_) => false,
         };

--- a/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
+++ b/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Fallible<()> {
             Err(_) => false,
         };
 
-        if counter % 30 == 0 {
+        if counter == 0 {
             conn_kitsune_proxy = match Command::new("proxy-cli")
                 .args(&["--", &args.flag_kitsune])
                 .output()
@@ -68,11 +68,9 @@ fn main() -> Fallible<()> {
                 },
                 Err(_) => false,
             };
-
-            counter = 0;
         };
         
-        counter = counter + 1;
+        counter = (counter + 1) % 30;
 
         let hpos_config_found = Path::new("/run/hpos-init/hpos-config.json").exists();
 

--- a/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
+++ b/overlays/holo-nixpkgs/hpos-led-manager/src/main.rs
@@ -45,6 +45,7 @@ fn main() -> Fallible<()> {
     let state_temp_path = state_path.with_extension("tmp");
 
     let mut counter: u8 = 0;
+    let mut conn_kitsune_proxy = true;
 
     loop {
         let router_gateway_addrs = "router-gateway.holo.host:80".to_socket_addrs();
@@ -55,8 +56,6 @@ fn main() -> Fallible<()> {
             },
             Err(_) => false,
         };
-        
-        let mut conn_kitsune_proxy = true;
 
         if counter % 30 == 0 {
             conn_kitsune_proxy = match Command::new("proxy-cli")

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -25,6 +25,8 @@ let
   holochainWorkingDir = "/var/lib/holochain-rsm";
 
   configureHolochainWorkingDir = "/var/lib/configure-holochain";
+
+  kitsuneAddress = "kitsune-proxy://CIW6PxKxsPPlcuvUCbMcKwUpaMSmB7kLD8xyyj4mqcw/kitsune-quic/h/165.22.32.11/p/5778/--";
 in
 
 {
@@ -77,6 +79,8 @@ in
   services.lair-keystore.enable = true;
 
   services.mingetty.autologinUser = "root";
+
+  services.hpos-led-manager.kitsuneAddress = kitsuneAddress;
 
   services.nginx = {
     enable = true;
@@ -199,7 +203,7 @@ in
           };
           proxy_config = {
             type = "remote_proxy_client";
-            proxy_url = "kitsune-proxy://CIW6PxKxsPPlcuvUCbMcKwUpaMSmB7kLD8xyyj4mqcw/kitsune-quic/h/165.22.32.11/p/5778/--";
+            proxy_url = kitsuneAddress;
           };
         }];
         tuning_params = {

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -43,7 +43,7 @@ in
   # REVIEW: `true` breaks gtk+ builds (cairo dependency)
   environment.noXlibs = false;
 
-  environment.systemPackages = [ git hc-state hpos-admin-client hpos-holochain-client hpos-reset hpos-update-cli holochainAllBinariesWithDeps.hpos.kitsune-p2p-proxy ];
+  environment.systemPackages = [ git hc-state hpos-admin-client hpos-holochain-client hpos-reset hpos-update-cli ];
 
   networking.firewall.allowedTCPPorts = [ 443 9000 ];
 

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -41,7 +41,7 @@ in
   # REVIEW: `true` breaks gtk+ builds (cairo dependency)
   environment.noXlibs = false;
 
-  environment.systemPackages = [ git hc-state hpos-admin-client hpos-holochain-client hpos-reset hpos-update-cli ];
+  environment.systemPackages = [ git hc-state hpos-admin-client hpos-holochain-client hpos-reset hpos-update-cli holochainAllBinariesWithDeps.hpos.kitsune-p2p-proxy ];
 
   networking.firewall.allowedTCPPorts = [ 443 9000 ];
 


### PR DESCRIPTION
If LED manager cannot make a proxy-cli call to the proxy server, it will start flashing orange

I tested this by giving it a fake proxy address and it seems to work fine. 