### PR TITLE
release.nix: fix Hydra evaluations with remote builders

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -31,6 +31,6 @@ in
       holo-nixpkgs = releaseTools.channel {
         name = "holo-nixpkgs";
         src = gitignoreSource ./.;
-        constituents = constitute (attrValues self);
+        constituents = constitute (attrNames self);
       };
     }


### PR DESCRIPTION
Use attrNames for constituents instead of attrValues. Fixes #746.

cc @grahamc