### PR TITLE
overlays/holo-nixpkgs/hpos-holochain-api: Catch up to new holochain

### DIFF
--- a/overlays/holo-nixpkgs/hpos-holochain-api/.gitignore
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 dnas
+/.hc*

--- a/overlays/holo-nixpkgs/hpos-holochain-api/README.md
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/README.md
@@ -91,7 +91,6 @@ This endpoint is called to install/enable a hosted happ by passing the happ_id a
 - ### Testing locally:
   - See that you are root of the `/hpos-holochain-api/` folder
   - `yarn install`
-  - To get the dna for testing run `yarn fetch-dnas`
   - In one terminal run `yarn holochain`
   - In a new terminal run `yarn test` to test out this module
   - After each test, make sure to <kbd>Ctrl</kbd>+<kbd>C</kbd> Holochain and re-run the command, in order to reset its state.

--- a/overlays/holo-nixpkgs/hpos-holochain-api/README.md
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/README.md
@@ -5,7 +5,7 @@ The hpos-holochain-api is an express server that exposes endpoints that interact
 ## Exposed Endpoints
 
 ### 1. `GET /hosted_happs`
-This endpoint is called to read all current hosted happs and return the usage data for each by passing the usageTimeInterval object to query usage entry data in each servicelogger instance
+This endpoint is called to read all current hosted happs and return the usage data for each by passing the usageTimeInterval object to query usage entry data in each `servicelogger` instance
 
 **Request Body**
 ```json
@@ -16,7 +16,7 @@ This endpoint is called to read all current hosted happs and return the usage da
 ```
 
 **Response Body:**
-#### Response with all successful servicelogger calls
+#### Response with all successful `servicelogger` calls
 `HTTP STATUS 200`:
 ```json
   [{ // enabled app with usage stats
@@ -68,7 +68,7 @@ Returns data for the dashboard page of host-console. Mostly usage data aggregate
 `bandwidth` and `currentTotalStorage` are both presented as number of *bytes*. `cpu` as number of *microseconds*.
 
 ### 3. `POST /install_hosted_happ`
-This endpoint is called to install/enable a hosted happ by passing the happ_id and preferences to set up the servicelogger instance
+This endpoint is called to install/enable a hosted happ by passing the happ_id and preferences to set up the `servicelogger` instance
 
 **Request Body**
 ```json

--- a/overlays/holo-nixpkgs/hpos-holochain-api/README.md
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/README.md
@@ -1,6 +1,6 @@
 # hpos-holochain-api
 
-The hpos-holochina-api is an express server that exposes endpoints that interact with holochain(i.e conductor) that is running in hpos.
+The hpos-holochain-api is an express server that exposes endpoints that interact with holochain(i.e conductor) that is running in hpos.
 
 ## Exposed Endpoints
 
@@ -91,9 +91,10 @@ This endpoint is called to install/enable a hosted happ by passing the happ_id a
 - ### Testing locally:
   - See that you are root of the `/hpos-holochain-api/` folder
   - `yarn install`
-  - To get the dna for testing run `npm run fetch-dnas`
-  - In one terminal run `npm run holochain`
-  - In a new terminal run `npm test` to test out this module
+  - To get the dna for testing run `yarn fetch-dnas`
+  - In one terminal run `yarn holochain`
+  - In a new terminal run `yarn test` to test out this module
+  - After each test, make sure to <kbd>Ctrl</kbd>+<kbd>C</kbd> Holochain and re-run the command, in order to reset its state.
 
 - ### Testing on hpos:
 

--- a/overlays/holo-nixpkgs/hpos-holochain-api/package.json
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "test": "jest --forceExit",
     "build": "webpack --config webpack.config.cjs",
-    "fetch-dnas": "sh ./scripts/fetch-dna.sh",
     "holochain": "node scripts/setup-holochain.js && hc sandbox -f=4444 run -p=42233"
   },
   "author": "robbie.carlton@holo.host",

--- a/overlays/holo-nixpkgs/hpos-holochain-api/package.json
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/package.json
@@ -10,12 +10,12 @@
     "test": "jest --forceExit",
     "build": "webpack --config webpack.config.cjs",
     "fetch-dnas": "sh ./scripts/fetch-dna.sh",
-    "holochain": "holochain-run-dna -c ./tests/config.yml -a 4444"
+    "holochain": "node scripts/setup-holochain.js && hc sandbox -f=4444 run -p=42233"
   },
   "author": "robbie.carlton@holo.host",
   "license": "ISC",
   "dependencies": {
-    "@holochain/conductor-api": "0.0.1-dev.16",
+    "@holochain/conductor-api": "0.0.1",
     "@msgpack/msgpack": "^2.3.0",
     "express": "^4.17.1",
     "fs": "0.0.1-security",

--- a/overlays/holo-nixpkgs/hpos-holochain-api/scripts/fetch-dna.sh
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/scripts/fetch-dna.sh
@@ -1,3 +1,0 @@
-mkdir dnas
-curl 'https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/v0.1.0-alpha1/holo-hosting-app.happ' -o ./dnas/holo-hosting-app.happ
-curl 'https://holo-host.github.io/servicelogger-rsm/releases/downloads/v0.1.0-alpha2/servicelogger.happ' -o ./dnas/servicelogger.happ

--- a/overlays/holo-nixpkgs/hpos-holochain-api/scripts/fetch-dna.sh
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/scripts/fetch-dna.sh
@@ -1,3 +1,3 @@
 mkdir dnas
-curl https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/v0.0.1-alpha6/holo-hosting-app.dna.gz -o ./dnas/holo-hosting-app.dna.gz
-curl https://holo-host.github.io/servicelogger-rsm/releases/downloads/v0.0.1-alpha6/servicelogger.dna.gz -o ./dnas/servicelogger.dna.gz
+curl 'https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/v0.1.0-alpha1/holo-hosting-app.happ' -o ./dnas/holo-hosting-app.happ
+curl 'https://holo-host.github.io/servicelogger-rsm/releases/downloads/v0.1.0-alpha2/servicelogger.happ' -o ./dnas/servicelogger.happ

--- a/overlays/holo-nixpkgs/hpos-holochain-api/scripts/setup-holochain.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/scripts/setup-holochain.js
@@ -25,7 +25,9 @@ async function main () {
   for (const happ of core_happs) {
     const { bundle_url, ui_url } = happ
     const bundlePath = await downloadFile(bundle_url)
-    const appId = new URL(bundle_url).pathname
+    const bundleUrlPath = new URL(bundle_url).pathname
+    const appId = bundleUrlPath
+      .slice(bundleUrlPath.lastIndexOf('/') + 1)
       .replace('.happ', '')
       .replace('.', ':')
 

--- a/overlays/holo-nixpkgs/hpos-holochain-api/scripts/setup-holochain.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/scripts/setup-holochain.js
@@ -2,6 +2,7 @@ const child_process = require('child_process')
 const { promisify } = require('util')
 const yaml = require('js-yaml')
 const fs = require('fs')
+const downloadFile = require('../src/utils.js')
 
 const exec = promisify(child_process.exec)
 const readFile = promisify(fs.readFile)
@@ -18,10 +19,13 @@ async function main () {
   await exec('hc sandbox clean')
   await exec('hc sandbox create')
   const agentPubKey = await newAgent()
-  const happs = yaml.load(await readFile('./tests/config.yaml', 'utf8'))
-  for (const happ of happs) {
-    const { dnas, app_name: appId } = happ
-    const [bundlePath] = dnas
+  const { core_happs, self_hosted_happs } = yaml.load(
+    await readFile('./tests/config.yaml', 'utf8')
+  )
+  for (const happ of core_happs) {
+    const { bundle_url, ui_url } = happ
+    const bundlePath = await downloadFile(bundle_url)
+
     await exec(
       `hc sandbox call install-app-bundle --agent-key '${agentPubKey}' --app-id '${appId}' '${bundlePath}'`
     )

--- a/overlays/holo-nixpkgs/hpos-holochain-api/scripts/setup-holochain.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/scripts/setup-holochain.js
@@ -1,0 +1,32 @@
+const child_process = require('child_process')
+const { promisify } = require('util')
+const yaml = require('js-yaml')
+const fs = require('fs')
+
+const exec = promisify(child_process.exec)
+const readFile = promisify(fs.readFile)
+
+const newAgent = async () => {
+  const agentKeyRegex = /(uhCAk[0-9A-Za-z_-]{48})/
+  const { stdout } = await exec('hc sandbox call new-agent', {
+    encoding: 'utf8'
+  })
+  return agentKeyRegex.exec(stdout)[1]
+}
+
+async function main () {
+  await exec('hc sandbox clean')
+  await exec('hc sandbox create')
+  const agentPubKey = await newAgent()
+  const happs = yaml.load(await readFile('./tests/config.yaml', 'utf8'))
+  for (const happ of happs) {
+    const { dnas, app_name: appId } = happ
+    const [bundlePath] = dnas
+    await exec(
+      `hc sandbox call install-app-bundle --agent-key '${agentPubKey}' --app-id '${appId}' '${bundlePath}'`
+    )
+  }
+  console.log((await exec('hc sandbox call list-active-apps')).stdout)
+}
+
+main()

--- a/overlays/holo-nixpkgs/hpos-holochain-api/scripts/setup-holochain.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/scripts/setup-holochain.js
@@ -2,7 +2,7 @@ const child_process = require('child_process')
 const { promisify } = require('util')
 const yaml = require('js-yaml')
 const fs = require('fs')
-const downloadFile = require('../src/utils.js')
+const { downloadFile } = require('../src/utils.js')
 
 const exec = promisify(child_process.exec)
 const readFile = promisify(fs.readFile)
@@ -25,6 +25,9 @@ async function main () {
   for (const happ of core_happs) {
     const { bundle_url, ui_url } = happ
     const bundlePath = await downloadFile(bundle_url)
+    const appId = new URL(bundle_url).pathname
+      .replace('.happ', '')
+      .replace('.', ':')
 
     await exec(
       `hc sandbox call install-app-bundle --agent-key '${agentPubKey}' --app-id '${appId}' '${bundlePath}'`

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/api.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/api.js
@@ -10,7 +10,8 @@ const installHostedHapp = async (
   happId,
   bundleUrl,
   agentPubKey,
-  serviceloggerPref
+  serviceloggerPref,
+  membraneProofs
 ) => {
   console.log('Installing hApp...', happId)
   // How to install a bundle
@@ -35,7 +36,7 @@ const installHostedHapp = async (
       path: bundlePath,
       agent_key: agentPubKey,
       installed_app_id: happId,
-      membrane_proofs: {}
+      membrane_proofs: membraneProofs || {}
     }
     console.log('Installing happ: ', payload)
     const installedApp = await adminWebsocket.installAppBundle(payload)
@@ -87,18 +88,26 @@ const installServicelogger = async (adminWebsocket, happId, preferences) => {
   await adminWebsocket.installApp({
     agent_key: hostPubKey,
     installed_app_id: installedApp,
-    dnas: [{
-      nick: 'servicelogger',
-      hash: registeredHash
-    }]
+    dnas: [
+      {
+        nick: 'servicelogger',
+        hash: registeredHash
+      }
+    ]
   })
 
   console.log(`Activating ${installedApp}...`)
   await adminWebsocket.activateApp({ installed_app_id: installedApp })
-  return callZome(appWebsocket, installedApp, 'service', 'set_logger_settings', preferences)
+  return callZome(
+    appWebsocket,
+    installedApp,
+    'service',
+    'set_logger_settings',
+    preferences
+  )
 }
 
-const createAgent = async (adminWebsocket) => {
+const createAgent = async adminWebsocket => {
   try {
     const agentPubKey = await adminWebsocket.generateAgentPubKey()
     console.log(`Generated new agent ${agentPubKey.toString('base64')}`)
@@ -108,7 +117,7 @@ const createAgent = async (adminWebsocket) => {
   }
 }
 
-const listInstalledApps = async (adminWebsocket) => {
+const listInstalledApps = async adminWebsocket => {
   try {
     const apps = await adminWebsocket.listActiveApps()
     console.log('listActiveApps app result: ', apps)
@@ -118,7 +127,7 @@ const listInstalledApps = async (adminWebsocket) => {
   }
 }
 
-const startHappInterface = async (adminWebsocket) => {
+const startHappInterface = async adminWebsocket => {
   try {
     console.log(`Starting app interface on port ${HAPP_PORT}`)
     await adminWebsocket.attachAppInterface({ port: HAPP_PORT })

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/api.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/api.js
@@ -2,13 +2,19 @@ const { ADMIN_PORT, HAPP_PORT, getAppIds } = require('./const')
 const { AdminWebsocket, AppWebsocket } = require('@holochain/conductor-api')
 const { downloadFile } = require('./utils')
 const msgpack = require('@msgpack/msgpack')
+const util = require('util')
 
 // NOTE: this code assumes a single DNA per hApp.  This will need to be updated when the hApp bundle
 // spec is completed, and the hosted-happ config Yaml file will also need to be likewise updated
-const installHostedHapp = async (happId, dna, agentPubKey, serviceloggerPref) => {
-  console.log('Installing DNA...', dna)
-  // How to install a DNA
-  // We need to download the DNA to a perticular location.
+const installHostedHapp = async (
+  happId,
+  bundleUrl,
+  agentPubKey,
+  serviceloggerPref
+) => {
+  console.log('Installing hApp...', happId)
+  // How to install a bundle
+  // We need to download the bundle to a perticular location.
   // Use that location and install
   // NOTE: we also have to install a servicelogger instance
   // We need to know the path to the servicelogger
@@ -21,57 +27,59 @@ const installHostedHapp = async (happId, dna, agentPubKey, serviceloggerPref) =>
     const adminWebsocket = await AdminWebsocket.connect(
       `ws://localhost:${ADMIN_PORT}`
     )
-    console.log('Downloading DNA URL...')
-    const payloadDna = []
-    for (let i = 0; i < dna.length; i++) {
+    console.log('Downloading bundle URL...', bundleUrl)
 
-      const dnaPath = await downloadFile(dna[i].src_url)
-      const registeredHash = await adminWebsocket.registerDna({
-        source: { path: dnaPath }
-      })
-      payloadDna.push({
-        nick: dna[i].nick,
-        hash: registeredHash
-      })
-    }
+    const bundlePath = await downloadFile(bundleUrl)
+
     const payload = {
+      path: bundlePath,
       agent_key: agentPubKey,
       installed_app_id: happId,
-      dnas: payloadDna
+      membrane_proofs: {}
     }
     console.log('Installing happ: ', payload)
-    const installedApp = await adminWebsocket.installApp(payload)
+    const installedApp = await adminWebsocket.installAppBundle(payload)
     console.log('Activate happ...', installedApp)
 
     // Install servicelogger instance
     await installServicelogger(adminWebsocket, happId, serviceloggerPref)
 
-    await adminWebsocket.activateApp({ installed_app_id: installedApp.installed_app_id })
-    console.log(`Successfully installed ${happId} (read-only instance and service logger) for key ${agentPubKey.toString('base64')}`)
+    await adminWebsocket.activateApp({
+      installed_app_id: installedApp.installed_app_id
+    })
+    console.log(
+      `Successfully installed ${happId} (read-only instance and service logger) for key ${agentPubKey.toString(
+        'base64'
+      )}`
+    )
   } catch (e) {
-    console.log(`Failed to install dna ${dna.nick} with error: `, e)
-    throw new Error(`Failed to install dna ${dna.nick} with error: `, e)
+    console.log(`Failed to install happ bundle ${happId} with error: `, e)
+    throw new Error(
+      `Failed to install happ bundle ${happId} with error: ${util.inspect(e)}`
+    )
   }
 }
 
 const installServicelogger = async (adminWebsocket, happId, preferences) => {
-  console.log(`Staring installation process of servicelogger for hosted happ {${happId}}`)
-  const appWebsocket = await AppWebsocket.connect(
-    `ws://localhost:${HAPP_PORT}`
+  console.log(
+    `Starting installation process of servicelogger for hosted happ {${happId}}`
   )
+  const appWebsocket = await AppWebsocket.connect(`ws://localhost:${HAPP_PORT}`)
   // TODO: Get servicelogger appID
   const APP_ID = await getAppIds()
-  const cell = await appWebsocket.appInfo({ installed_app_id: APP_ID.SL })
-  const serviceloggerDnaHash = cell.cell_data[0][0][0]
-  const hostPubKey = cell.cell_data[0][0][1]
+  const {
+    cell_data: [
+      {
+        cell_id: [serviceloggerDnaHash, hostPubKey]
+      }
+    ]
+  } = await appWebsocket.appInfo({ installed_app_id: APP_ID.SL })
 
   const installedApp = `${happId}::servicelogger`
-  console.log(`Registring ${installedApp}...`)
+  console.log(`Registering ${installedApp}...`)
 
   const registeredHash = await adminWebsocket.registerDna({
-    source: {
-      hash: serviceloggerDnaHash
-    },
+    hash: serviceloggerDnaHash,
     properties: Array.from(msgpack.encode({ bound_happ_id: happId }))
   })
 
@@ -125,10 +133,11 @@ const callZome = async (ws, installedAppId, zomeName, fnName, payload) => {
   if (!appInfo) {
     throw new Error(`Couldn't find Holo Hosting App with id ${installedAppId}`)
   }
-  const cellId = appInfo.cell_data[0][0]
-  const agentKey = cellId[1]
+  const [{ cell_id }] = appInfo.cell_data
+  const [_dnaHash, agentKey] = cell_id
+
   return ws.callZome({
-    cell_id: cellId,
+    cell_id,
     zome_name: zomeName,
     fn_name: fnName,
     provenance: agentKey,

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/const.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/const.js
@@ -24,7 +24,7 @@ const getAppIds = async () => {
   try {
     const config = yaml.load(fs.readFileSync(CONFIGURE_HC, 'utf8'))
     const getId = (name) => {
-      const bundle_url = config.core_happs.find(h => h.bundle_url.includes(name))
+      const { bundle_url } = config.core_happs.find(h => h.bundle_url.includes(name))
       return new URL(bundle_url).pathname
       .replace('.happ', '')
       .replace('.', ':')

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/const.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/const.js
@@ -31,7 +31,7 @@ const getAppIds = async () => {
         .replace('.', ':')
     }
     return {
-      HHA: getId('holo-hosting-app'),
+      HHA: getId('core-app'),
       SL: getId('servicelogger')
     }
   } catch (e) {

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/const.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/const.js
@@ -7,7 +7,7 @@ const ADMIN_PORT = 4444
 
 const HAPP_PORT = 42233
 
-const CONFIGURE_HC = process.env.NODE_ENV === 'test' ? './tests/config.yml' : '/var/lib/configure-holochain/config.yaml'
+const CONFIGURE_HC = process.env.NODE_ENV === 'test' ? './tests/config.yaml' : '/var/lib/configure-holochain/config.yaml'
 const READ_ONLY_PUBKEY = '/var/lib/configure-holochain/agent_key.pub'
 
 const getReadOnlyPubKey = async () => {
@@ -22,7 +22,7 @@ const getReadOnlyPubKey = async () => {
 
 const getAppIds = async () => {
   try {
-    const config = await yaml.load(fs.readFileSync(CONFIGURE_HC, 'utf8'))
+    const config = yaml.load(fs.readFileSync(CONFIGURE_HC, 'utf8'))
     const getId = (id) => {
       const app = config.core_happs.find(h => h.app_id === id)
       if (app.uuid === undefined) {

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/const.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/const.js
@@ -25,9 +25,10 @@ const getAppIds = async () => {
     const config = yaml.load(fs.readFileSync(CONFIGURE_HC, 'utf8'))
     const getId = (name) => {
       const { bundle_url } = config.core_happs.find(h => h.bundle_url.includes(name))
-      return new URL(bundle_url).pathname
-      .replace('.happ', '')
-      .replace('.', ':')
+      const bundleUrlPath = new URL(bundle_url).pathname
+      return bundleUrlPath.slice(bundleUrlPath.lastIndexOf('/') + 1)
+        .replace('.happ', '')
+        .replace('.', ':')
     }
     return {
       HHA: getId('holo-hosting-app'),

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/const.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/const.js
@@ -23,24 +23,15 @@ const getReadOnlyPubKey = async () => {
 const getAppIds = async () => {
   try {
     const config = yaml.load(fs.readFileSync(CONFIGURE_HC, 'utf8'))
-    const getId = (id) => {
-      const app = config.core_happs.find(h => h.app_id === id)
-      if (app.uuid === undefined) {
-        return `${id}:${app.version}`
-      } else {
-        return `${id}:${app.version}:${app.uuid}`
-      }
+    const getId = (name) => {
+      const bundle_url = config.core_happs.find(h => h.bundle_url.includes(name))
+      return new URL(bundle_url).pathname
+      .replace('.happ', '')
+      .replace('.', ':')
     }
-    if (process.env.NODE_ENV === 'test') {
-      return {
-        HHA: config[0].app_name,
-        SL: config[1].app_name
-      }
-    } else {
-      return {
-        HHA: getId('core-happs'),
-        SL: getId('servicelogger')
-      }
+    return {
+      HHA: getId('holo-hosting-app'),
+      SL: getId('servicelogger')
     }
   } catch (e) {
     throw new Error(e)

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
@@ -167,7 +167,7 @@ app.post('/install_hosted_happ', async (req, res) => {
       } else {
         const serviceloggerPref = parsePreferences(preferences, happBundleDetails.provider_pubkey)
         console.log('Parsed Preferences: ', serviceloggerPref)
-        await installHostedHapp(happBundleDetails.happ_id, happBundleDetails.happ_bundle.bundle_url, hostPubKey, serviceloggerPref)
+        await installHostedHapp(happBundleDetails.happ_id, happBundleDetails.happ_bundle.bundle_url, hostPubKey, serviceloggerPref, data.membrane_proofs)
       }
 
       // Note: Do not need to install UI's for hosted happ

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
@@ -58,10 +58,13 @@ const getPresentedHapps = async usageTimeInterval => {
 }
 
 app.get('/hosted_happs', async (req, res) => {
-  const usageTimeInterval = await new Promise(resolve => req.on('data', (body) => {
-    resolve(JSON.parse(body.toString()))
-  }))
-  if (!isusageTimeInterval(usageTimeInterval)) return res.status(501).send('error from /hosted_happs: param provided is not an object')
+  const usageTimeInterval = await Promise.race([
+    new Promise(resolve => req.on('data', (body) => {
+      resolve(JSON.parse(body.toString()))
+    })), 
+    new Promise(resolve => setTimeout(() => resolve(undefined), 100))
+  ])
+  if (usageTimeInterval !== undefined && !isusageTimeInterval(usageTimeInterval)) return res.status(501).send('error from /hosted_happs: param provided is not an object')
 
   try {
     const presentedHapps = await getPresentedHapps(usageTimeInterval)

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
@@ -151,6 +151,7 @@ app.post('/install_hosted_happ', async (req, res) => {
       return res.status(501).send(`hpos-holochain-api error: ${e}`)
     }
     console.log('Happ Bundle: ', happBundleDetails)
+    console.log('DNAS', happBundleDetails.happ_bundle.dnas)
     let listOfInstalledHapps
     // Instalation Process:
     try {
@@ -163,16 +164,13 @@ app.post('/install_hosted_happ', async (req, res) => {
       // Generate new agent in a test environment else read the location in hpos
       const hostPubKey = process.env.NODE_ENV === 'test' ? await createAgent(adminWs) : await getReadOnlyPubKey()
 
-      // Install DNAs
-      const dnas = happBundleDetails.happ_bundle.dnas
-
       // check if the hosted_happ is already listOfInstalledHapps
       if (listOfInstalledHapps.includes(`${happBundleDetails.happ_id}`)) {
         return res.status(501).send(`hpos-holochain-api error: ${happBundleDetails.happ_id} already installed on your holoport`)
       } else {
         const serviceloggerPref = parsePreferences(preferences, happBundleDetails.provider_pubkey)
         console.log('Parsed Preferences: ', serviceloggerPref)
-        await installHostedHapp(happBundleDetails.happ_id, dnas, hostPubKey, serviceloggerPref)
+        await installHostedHapp(happBundleDetails.happ_id, happBundleDetails.happ_bundle.bundle_url, hostPubKey, serviceloggerPref)
       }
 
       // Note: Do not need to install UI's for hosted happ

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
@@ -58,11 +58,10 @@ const getPresentedHapps = async usageTimeInterval => {
 }
 
 app.get('/hosted_happs', async (req, res) => {
-  let usageTimeInterval
-  await req.on('data', (body) => {
-    usageTimeInterval = JSON.parse(body.toString())
+  const usageTimeInterval = await new Promise(resolve => req.on('data', (body) => {
+    resolve(JSON.parse(body.toString()))
     if (!isusageTimeInterval(usageTimeInterval)) return res.status(501).send('error from /hosted_happs: param provided is not an object')
-  })
+  }))
 
   try {
     const presentedHapps = await getPresentedHapps(usageTimeInterval)
@@ -73,11 +72,10 @@ app.get('/hosted_happs', async (req, res) => {
 })
 
 app.get('/dashboard', async (req, res) => {
-  let usageTimeInterval
-  await req.on('data', (body) => {
-    usageTimeInterval = JSON.parse(body.toString())
+  const usageTimeInterval = await new Promise(resolve => req.on('data', (body) => {
+    resolve(JSON.parse(body.toString()))
     if (!isusageTimeInterval(usageTimeInterval)) return res.status(501).send('error from /hosted_happs: param provided is not an object')
-  })
+  }))
 
   try {
     const presentedHapps = await getPresentedHapps(usageTimeInterval)
@@ -113,11 +111,10 @@ app.get('/dashboard', async (req, res) => {
 })
 
 app.post('/install_hosted_happ', async (req, res) => {
-  let data
   // Loading body
-  await req.on('data', (body) => {
-    data = JSON.parse(body.toString())
-  })
+  const data = await new Promise(resolve => req.on('data', (body) => {
+    resolve(JSON.parse(body.toString()))
+  }))
 
   // check if happ_id is passed else return error
   if (data.happ_id && data.preferences) {

--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
@@ -60,8 +60,8 @@ const getPresentedHapps = async usageTimeInterval => {
 app.get('/hosted_happs', async (req, res) => {
   const usageTimeInterval = await new Promise(resolve => req.on('data', (body) => {
     resolve(JSON.parse(body.toString()))
-    if (!isusageTimeInterval(usageTimeInterval)) return res.status(501).send('error from /hosted_happs: param provided is not an object')
   }))
+  if (!isusageTimeInterval(usageTimeInterval)) return res.status(501).send('error from /hosted_happs: param provided is not an object')
 
   try {
     const presentedHapps = await getPresentedHapps(usageTimeInterval)
@@ -74,8 +74,8 @@ app.get('/hosted_happs', async (req, res) => {
 app.get('/dashboard', async (req, res) => {
   const usageTimeInterval = await new Promise(resolve => req.on('data', (body) => {
     resolve(JSON.parse(body.toString()))
-    if (!isusageTimeInterval(usageTimeInterval)) return res.status(501).send('error from /hosted_happs: param provided is not an object')
   }))
+  if (!isusageTimeInterval(usageTimeInterval)) return res.status(501).send('error from /hosted_happs: param provided is not an object')
 
   try {
     const presentedHapps = await getPresentedHapps(usageTimeInterval)

--- a/overlays/holo-nixpkgs/hpos-holochain-api/tests/config.yaml
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/tests/config.yaml
@@ -1,11 +1,8 @@
-# HoloHosting App
-- dnas:
-  - ./dnas/holo-hosting-app.happ
-  app_name: core-happs:alpha0
-  app_port: 42233
-
-# Servicelogger App
-- dnas:
-  - ./dnas/servicelogger.happ
-  app_name: servicelogger:alpha0
-  app_port: 42233
+core_happs:
+  # HoloHosting App
+  - bundle_url: https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/v0.1.0-alpha1/holo-hosting-app.happ
+    ui_url: https://example.org
+  # Servicelogger App
+  - bundle_url: https://holo-host.github.io/servicelogger-rsm/releases/downloads/v0.1.0-alpha2/servicelogger.happ
+    ui_url: https://example.org
+self_hosted_happs: []

--- a/overlays/holo-nixpkgs/hpos-holochain-api/tests/config.yaml
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/tests/config.yaml
@@ -1,6 +1,6 @@
 core_happs:
   # HoloHosting App
-  - bundle_url: https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/v0.1.0-alpha1/holo-hosting-app.happ
+  - bundle_url: https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/v0.1.0-alpha2/core-app.happ
     ui_url: https://example.org
   # Servicelogger App
   - bundle_url: https://holo-host.github.io/servicelogger-rsm/releases/downloads/v0.1.0-alpha2/servicelogger.happ

--- a/overlays/holo-nixpkgs/hpos-holochain-api/tests/config.yaml
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/tests/config.yaml
@@ -1,11 +1,11 @@
 # HoloHosting App
 - dnas:
-  - ./dnas/holo-hosting-app.dna.gz
+  - ./dnas/holo-hosting-app.happ
   app_name: core-happs:alpha0
   app_port: 42233
 
 # Servicelogger App
 - dnas:
-  - ./dnas/servicelogger.dna.gz
+  - ./dnas/servicelogger.happ
   app_name: servicelogger:alpha0
   app_port: 42233

--- a/overlays/holo-nixpkgs/hpos-holochain-api/tests/index.test.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/tests/index.test.js
@@ -19,12 +19,13 @@ function delay(t, val) {
 test('holochain-api endpoint ', async () => {
   const listOfHappsResponse = await request(app).get('/hosted_happs').send(usageTimeInterval)
   expect(listOfHappsResponse.status).toBe(200)
-  expect(listOfHappsResponse.body[0].name).toBe(HAPP_NAME)
-  expect(listOfHappsResponse.body[0].enabled).toBe(false)
-  expect(listOfHappsResponse.body[0].error.message).toBeTruthy()
-  expect(listOfHappsResponse.body[0].error.source).toBeTruthy()
-  expect(listOfHappsResponse.body[0].sourceChains).toBeFalsy()
-  expect(listOfHappsResponse.body[0].usage).toBeFalsy()
+  const listOfHapps = JSON.parse(listOfHappsResponse.text)
+  expect(listOfHapps[0].name).toBe(HAPP_NAME)
+  expect(listOfHapps[0].enabled).toBe(false)
+  expect(listOfHapps[0].error.message).toBeTruthy()
+  expect(listOfHapps[0].error.source).toBeTruthy()
+  expect(listOfHapps[0].sourceChains).toBeFalsy()
+  expect(listOfHapps[0].usage).toBeFalsy()
 
   const preferences = {
     "max_fuel_before_invoice": 1,
@@ -36,22 +37,23 @@ test('holochain-api endpoint ', async () => {
 
   const res = await request(app)
     .post('/install_hosted_happ')
-    .send({ happ_id: listOfHappsResponse.body[0].id, preferences })
+    .send({ happ_id: listOfHapps[0].id, preferences })
   expect(res.status).toBe(200)
 
   await delay(10000)
 
-  const listOfHappsReload = await request(app).get('/hosted_happs').send(usageTimeInterval)
+  const listOfHappsReloadResponse = await request(app).get('/hosted_happs').send(usageTimeInterval)
   const usage = {
     bandwidth: 0,
     cpu: 0
   }
-  expect(listOfHappsReload.status).toBe(200)
-  expect(listOfHappsReload.body[0].enabled).toBe(true)
-  expect(listOfHappsReload.body[0].name).toBe(HAPP_NAME)
-  expect(listOfHappsReload.body[0].sourceChains).toBe(0)
-  expect(listOfHappsReload.body[0].storage).toBe(0)
-  expect(listOfHappsReload.body[0].usage).toStrictEqual(usage)
+  expect(listOfHappsReloadResponse.status).toBe(200)
+  const listOfHappsReload = JSON.parse(listOfHappsReloadResponse.text)
+  expect(listOfHappsReload[0].enabled).toBe(true)
+  expect(listOfHappsReload[0].name).toBe(HAPP_NAME)
+  expect(listOfHappsReload[0].sourceChains).toBe(0)
+  expect(listOfHappsReload[0].storage).toBe(0)
+  expect(listOfHappsReload[0].usage).toStrictEqual(usage)
 }, 50000)
 
 test('dashboard endpoint', async () => {

--- a/overlays/holo-nixpkgs/hpos-holochain-api/yarn.lock
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/yarn.lock
@@ -295,10 +295,10 @@
     tmp "^0.2.1"
     yargs "^16.1.1"
 
-"@holochain/conductor-api@0.0.1-dev.14":
-  version "0.0.1-dev.14"
-  resolved "https://registry.yarnpkg.com/@holochain/conductor-api/-/conductor-api-0.0.1-dev.14.tgz#e8a88cefdbe79611f1f43933a4a221df33c60198"
-  integrity sha512-Y10clXo6T6ln5QcHSznQZgzj0Fph000d916RQJKs4qRbD+kU55dYaqoS4AZwAmYoQskeR6i7eF7XPgUD7QYv9A==
+"@holochain/conductor-api@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@holochain/conductor-api/-/conductor-api-0.0.1.tgz#a45c32d9d7713232dfab6833d4363b3a20cc157a"
+  integrity sha512-Vng5LG8JN1Zh7/s8OMOQKVih/Cz4zJo/6xpXnOYX148XC8bakKuaRXV08sTUWZMKElbq4BqZFTVcxJw3ouPt+w==
   dependencies:
     "@msgpack/msgpack" "^2.1.0"
     "@types/ws" "^7.2.4"
@@ -306,10 +306,10 @@
     nanoid "^3.1.9"
     ws "^7.3.0"
 
-"@holochain/conductor-api@0.0.1-dev.16":
-  version "0.0.1-dev.16"
-  resolved "https://registry.yarnpkg.com/@holochain/conductor-api/-/conductor-api-0.0.1-dev.16.tgz#c9da19859dbab0caec0cdbb6da04b8bf999dc04b"
-  integrity sha512-MGBj/vnmnzf5RYZnpCjmj+d+OAScNTzNd4TuNZ1eeHnnX08rLa2UPavXtEkNxS4Vkg8PdRfDXX40Imilbup01A==
+"@holochain/conductor-api@0.0.1-dev.14":
+  version "0.0.1-dev.14"
+  resolved "https://registry.yarnpkg.com/@holochain/conductor-api/-/conductor-api-0.0.1-dev.14.tgz#e8a88cefdbe79611f1f43933a4a221df33c60198"
+  integrity sha512-Y10clXo6T6ln5QcHSznQZgzj0Fph000d916RQJKs4qRbD+kU55dYaqoS4AZwAmYoQskeR6i7eF7XPgUD7QYv9A==
   dependencies:
     "@msgpack/msgpack" "^2.1.0"
     "@types/ws" "^7.2.4"

--- a/overlays/holo-nixpkgs/hpos-holochain-client/hpos-holochain-client.py
+++ b/overlays/holo-nixpkgs/hpos-holochain-client/hpos-holochain-client.py
@@ -17,7 +17,7 @@ def request(ctx, method, path, **kwargs):
 @cli.command(help='Get info on happs currently hosted')
 @click.pass_context
 def hosted_happs(ctx):
-    print(request(ctx, 'GET', '/hosted_happs').json())
+    print(request(ctx, 'GET', '/hosted_happs').text)
 
 @cli.command(help='Pass a happ_id to be installed as a hosted happ')
 @click.argument('happ_id')


### PR DESCRIPTION
Changes:
- Update to use `@holochain/conductor-api@0.1.0`
- Update to use `bundle_url` provided by HHA for installing hosted happs, rather than using each `dna_url` individually.
- Update to use `hc sandbox` instead of `holochain-run-dna`
- Update the versions of servicelogger and HHA that get downloaded for testing
- Fix pre-existing apparent bug where we don't reliably wait for input to come through when handling an HTTP request (Hasn't seemed to show up in practice though)

I did not end up changing the servicelogger cloning mechanism. I tried using the newly introduced `createCloneCell` but it only allows you to clone cells such that they end up inside of an already active app. In the future it might make sense to move all of the servicelogger instances into one app, and use `slotId`s to identify them and `createCloneCell` to clone them.