### PR TITLE
prevent server crash, in case of bad formatted json

### DIFF
--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/utils.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/utils.js
@@ -60,7 +60,7 @@ const toInt = i => {
 }
 
 const isusageTimeInterval = value => {
-  if (value === null) return false
+  if (value === null || value === undefined) return false
   const keys = Object.keys(value)
   return keys.includes('duration_unit') && keys.includes('amount')
 }

--- a/overlays/holo-nixpkgs/hpos-holochain-api/tests/index.test.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/tests/index.test.js
@@ -17,6 +17,9 @@ function delay(t, val) {
 }
 
 test('holochain-api endpoint ', async () => {
+  const listOfHappsResponse = await request(app).get('/hosted_happs').send('badjson')
+  expect(listOfHappsResponse.status).toBe(400)
+
   const listOfHappsResponse = await request(app).get('/hosted_happs').send(usageTimeInterval)
   expect(listOfHappsResponse.status).toBe(200)
   const listOfHapps = JSON.parse(listOfHappsResponse.text)

--- a/overlays/holo-nixpkgs/hpos-holochain-api/tests/index.test.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/tests/index.test.js
@@ -17,8 +17,8 @@ function delay(t, val) {
 }
 
 test('holochain-api endpoint ', async () => {
-  const listOfHappsResponse = await request(app).get('/hosted_happs').send('badjson')
-  expect(listOfHappsResponse.status).toBe(400)
+  const badHostedHappsRequest = await request(app).get('/hosted_happs').send('badjson')
+  expect(badHostedHappsRequest.status).toBe(501)
 
   const listOfHappsResponse = await request(app).get('/hosted_happs').send(usageTimeInterval)
   expect(listOfHappsResponse.status).toBe(200)
@@ -37,6 +37,9 @@ test('holochain-api endpoint ', async () => {
     "price_storage": 2,
     "price_bandwidth": 1
   }
+
+  const badInstallHostedHappRequest = await request(app).post('/install_hosted_happ').send('badjson')
+  expect(badInstallHostedHappRequest.status).toBe(501)
 
   const res = await request(app)
     .post('/install_hosted_happ')
@@ -64,6 +67,9 @@ test('dashboard endpoint', async () => {
     duration_unit: 'DAY',
     amount: 1
   }
+
+  const badDashboardRequest = await request(app).get('/dashboard').send('badjson')
+  expect(badDashboardRequest.status).toBe(501)
 
   const dashboardResponse = await request(app).get('/dashboard').send(usageTimeInterval)
   expect(dashboardResponse.status).toBe(200)


### PR DESCRIPTION
I was reading through PRs and came on something that looked like it had a hole
 
The following test failure occurs when I simply added a certain string formatting that's not valid JSON, because a JSON.parse call was not in a try/catch block, and it always should be, especially on the server side
```
  ● holochain-api endpoint

    SyntaxError: Unexpected token b in JSON at position 0
        at JSON.parse (<anonymous>)

      61 |   const usageTimeInterval = await Promise.race([
      62 |     new Promise(resolve => req.on('data', (body) => {
    > 63 |       resolve(JSON.parse(body.toString()))
         |                    ^
      64 |     })),
      65 |     new Promise(resolve => setTimeout(() => resolve(undefined), 100))
      66 |   ])

      at IncomingMessage.<anonymous> (src/index.js:63:20)
```