### PR TITLE
D-012420 fix regression and hpos-holochain-client bug

### DIFF
--- a/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
+++ b/overlays/holo-nixpkgs/hpos-holochain-api/src/index.js
@@ -59,13 +59,14 @@ const getPresentedHapps = async usageTimeInterval => {
 }
 
 app.get('/hosted_happs', async (req, res) => {
-  const usageTimeInterval = await Promise.race([
-    new Promise(resolve => req.on('data', (body) => {
-      resolve(JSON.parse(body.toString()))
-    })),
-    new Promise(resolve => setTimeout(() => resolve(undefined), 100))
-  ])
-  if (usageTimeInterval !== undefined && !isusageTimeInterval(usageTimeInterval)) return res.status(501).send('error from /hosted_happs: param provided is not an object')
+  const usageTimeInterval = {
+    duration_unit: req.query.duration_unit,
+    amount: Number(req.query.amount)
+  }
+
+  if (!isUsageTimeInterval(usageTimeInterval)) {
+    return res.status(501).send('failed to provide proper time interval query params: expected duration_unit and amount')
+  }
 
   try {
     const presentedHapps = await getPresentedHapps(usageTimeInterval)

--- a/overlays/holo-nixpkgs/hpos-holochain-client/hpos-holochain-client.py
+++ b/overlays/holo-nixpkgs/hpos-holochain-client/hpos-holochain-client.py
@@ -26,7 +26,7 @@ def hosted_happs(ctx, amount, duration_unit):
 @click.argument('duration_unit')
 @click.pass_context
 def dashboard(ctx):
-    print(request(ctx, 'GET', "/dashboard?duration_unit={duration_unit}&amount={amount}").text)
+    print(request(ctx, 'GET', f"/dashboard?duration_unit={duration_unit}&amount={amount}").text)
 
 @cli.command(help='Pass a happ_id to be installed as a hosted happ')
 @click.argument('happ_id')

--- a/overlays/holo-nixpkgs/hpos-holochain-client/hpos-holochain-client.py
+++ b/overlays/holo-nixpkgs/hpos-holochain-client/hpos-holochain-client.py
@@ -19,12 +19,14 @@ def request(ctx, method, path, **kwargs):
 @click.argument('duration_unit')
 @click.pass_context
 def hosted_happs(ctx, amount, duration_unit):
-    print(request(ctx, 'GET', '/hosted_happs?duration_unit=${duration_unit}&amount=${amount}').text)
+    print(request(ctx, 'GET', f"/hosted_happs?duration_unit={duration_unit}&amount={amount}").text)
 
 @cli.command(help='Get info for the host-console-ui dashboard')
+@click.argument('amount')
+@click.argument('duration_unit')
 @click.pass_context
 def dashboard(ctx):
-    print(request(ctx, 'GET', '/dashboard').text)
+    print(request(ctx, 'GET', "/dashboard?duration_unit={duration_unit}&amount={amount}").text)
 
 @cli.command(help='Pass a happ_id to be installed as a hosted happ')
 @click.argument('happ_id')


### PR DESCRIPTION
This fixes a regression in `hpos-holochain-api` that was trying to read the body of `GET /hosted_happs` rather than getting the args from the query string.

It also fixes a bug in `hpos-holochain-client` where we were not properly passing the args in the query string.