### PR TITLE
Bumps holochain to Synchronous Genesis

### DIFF
--- a/overlays/holo-nixpkgs/holochain/versions.nix
+++ b/overlays/holo-nixpkgs/holochain/versions.nix
@@ -1,8 +1,8 @@
 {
   hpos = {
-    rev = "d292df185a1c463ded0d904e9d7846fa237d3225";
-    sha256 = "011ys8j81bzifa1pg131b33zy1w8r7kkblas099kbj97dj7qz9xm";
-    cargoSha256 = "0gp6j94zjk75axs9nzp8f5d2lhygq1isllf6fnbv7gh9v8q18ryy";
+    rev = "a1ae76ecc1fc7dbd645fee3a8cb0df9f610be983";
+    sha256 = "04kha2vxzh3ml452xsdz40f3jbchlad0lf741862n56x4np2spa2";
+    cargoSha256 = "0q9nl0wqvyd5jbxq92f1h4l7i439kl5j1bkzxlz929q4m43r3apn";
     bins = {
       holochain = "holochain";
       hc = "hc";


### PR DESCRIPTION
 - Updates to holochain hpos rev to `a1ae76ecc1fc7dbd645fee3a8cb0df9f610be983`
 
 > NB: This follows holochain [PR # 754](https://github.com/holochain/holochain/pull/754).