### PR TITLE
overlays/holo-nixpkgs/holo-envoy: Update

### DIFF
--- a/overlays/holo-nixpkgs/holo-envoy/default.nix
+++ b/overlays/holo-nixpkgs/holo-envoy/default.nix
@@ -15,8 +15,8 @@ mkYarnPackage rec {
   src = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-envoy";
-    rev = "850cbc8514c6ffe1f86eae95b4278869119346bc";
-    sha256 = "0bl7i6gv80f7hwdljxgnm6zncac87ll4k1hmdsajsbi5l2aaf5hh";
+    rev = "f44b1b6cd259bbf3f5bfcd4f5fc3955e60d1b315";
+    sha256 = "0xhqqnzxr4zl98sxm1v718g8kkizdavy5sqpqsvh9wfmjp3sglfv";
   };
 
   buildInputs = [ python ];


### PR DESCRIPTION
### Updates:
 - adds tip of holo-envoy [PR #124](https://github.com/Holo-Host/holo-envoy/pull/124)
 
 > NB: This PR is branched off of Synchronous Genesis PR #807, and also references hololchain rev `a1ae76ecc1fc7dbd645fee3a8cb0df9f610be983`.