### PR TITLE
Resilient Hosted Happs

### DIFF
--- a/modules/services/holo-envoy.nix
+++ b/modules/services/holo-envoy.nix
@@ -29,7 +29,7 @@ in
       '';
 
       serviceConfig = {
-        Environment = "LOG_LEVEL=silly";
+        Environment = "LOG_LEVEL=debug";
         ExecStart = "${cfg.package}/bin/holo-envoy";
         TimeoutStartSec = 300;
         Restart = "always";

--- a/modules/services/holo-envoy.nix
+++ b/modules/services/holo-envoy.nix
@@ -29,7 +29,7 @@ in
       '';
 
       serviceConfig = {
-        Environment = "LOG_LEVEL=debug";
+        Environment = "LOG_LEVEL=silly";
         ExecStart = "${cfg.package}/bin/holo-envoy";
         TimeoutStartSec = 300;
         Restart = "always";

--- a/overlays/holo-nixpkgs/holo-envoy/default.nix
+++ b/overlays/holo-nixpkgs/holo-envoy/default.nix
@@ -15,8 +15,8 @@ mkYarnPackage rec {
   src = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-envoy";
-    rev = "0a346344345c83165f9b71feeab430ad89cde96c";
-    sha256 = "08z0scyhf7cbs3av76lh66i1y9182r2cb8j84qha3xzagi1k3gss";
+    rev = "f44b1b6cd259bbf3f5bfcd4f5fc3955e60d1b315";
+    sha256 = "0xhqqnzxr4zl98sxm1v718g8kkizdavy5sqpqsvh9wfmjp3sglfv";
   };
 
   buildInputs = [ python ];

--- a/overlays/holo-nixpkgs/holochain/versions.nix
+++ b/overlays/holo-nixpkgs/holochain/versions.nix
@@ -1,7 +1,7 @@
 {
   hpos = {
-    rev = "24477159cd80f3a44fd82bba60baa360e76b9f0d";
-    sha256 = "1qiypsr37v5m1sqbz2mnlwfrnksds88ag8m78fjwszsh6nx1yhgz";
+    rev = "1050f6b064a44a6d6b845940bf4b83cb92f0472f";
+    sha256 = "0pr2nfqvc416yq44py3w5r71a25bxjjypn0m2x5mp95qnbf0619k";
     cargoSha256 = "0q9nl0wqvyd5jbxq92f1h4l7i439kl5j1bkzxlz929q4m43r3apn";
     bins = {
       holochain = "holochain";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -232,7 +232,7 @@ in
       core_happs = [
        {
          app_id = "core-app";
-         bundle_url = "https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/v0.1.0-alpha9/core-app.0_1_0_alpha10.happ";
+         bundle_url = "https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/v0.1.0-alpha10/core-app.0_1_0_alpha10.happ";
        }
        {
          app_id = "servicelogger";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -232,7 +232,7 @@ in
       core_happs = [
        {
          app_id = "core-app";
-         bundle_url = "https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/v0.1.0-alpha8/core-app.0_1_0_alpha8.happ";
+         bundle_url = "https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/v0.1.0-alpha9/core-app.0_1_0_alpha10.happ";
        }
        {
          app_id = "servicelogger";


### PR DESCRIPTION
Includes
- Holochain tip of `sync-genesis` branch (`1050f6b`)
- Holo-Envoy tip of PR 124
- HHA v0.1.0-alpha10 (points to elemental chat v0.2.0-alpha7)