### PR TITLE
Bump holochain that uses wasmer updates

### DIFF
--- a/overlays/holo-nixpkgs/configure-holochain/default.nix
+++ b/overlays/holo-nixpkgs/configure-holochain/default.nix
@@ -7,11 +7,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "hpos-configure-holochain";
-    rev = "1b8c152960259966e8b90891094b265863be7edf";
-    sha256 = "146p0lxrqgy9y4sdm78xhjpvhc3jdkdhlb022v2is8djd1ckslfp";
+    rev = "31a339e961bbe7b9177f3a721b5d29801c0d274b";
+    sha256 = "1m68nqww9gz2hki4n3xv86c6wr1kgf7snbbf7nnsbb26dhb5qlhm";
   };
 
-  cargoSha256 = "0k1zr5adaapj5vsxk17nx3y2yl5li44jvd5hmjgmq7099crf1di0";
+  cargoSha256 = "1n9pywziayyhvr2sjp595psh5niahvdl2d1lmblklkvarbp58c1d";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ];

--- a/overlays/holo-nixpkgs/default.nix
+++ b/overlays/holo-nixpkgs/default.nix
@@ -277,8 +277,8 @@ rec {
     }).rust.override { inherit targets; };
 
     rustStable = (rustChannelOf {
-      channel = "1.48.0";
-      sha256 = "0b56h3gh577wv143ayp46fv832rlk8yrvm7zw1dfiivifsn7wfzg";
+      channel = "1.52.0";
+      sha256 = "0qzaq3hsxh7skxjix4d4k38rv0cxwwnvi32arg08p11cxvpsmikx";
     }).rust.override { inherit targets; };
   in {
     packages = previous.rust.packages // {

--- a/overlays/holo-nixpkgs/holo-auto-installer/default.nix
+++ b/overlays/holo-nixpkgs/holo-auto-installer/default.nix
@@ -7,11 +7,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "Holo-Host";
     repo = "holo-auto-installer";
-    rev = "5020f89dcab36026597eb723fe32aa94c94518da";
-    sha256 = "19alaa1a2z12vy5y97lm62q3g8ln0bxyblrndmap3622y1pc817z";
+    rev = "cc996b3f1389296bf7756adbf4cd13b7152c43d0";
+    sha256 = "00bx4hsy5z5kxisqk9fnl6fi5cazkpa21nx7k8kibz5f07nsa3bl";
   };
 
-  cargoSha256 = "0kwldg2qa6i2f8ih6yhwzm6m59683zg551w962qvyhcm9xyny283";
+  cargoSha256 = "1kzg4zwxnkh2h9mzh0mrrhfsyg94gc5x3wcdf8f8afpcpks72jhc";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ];

--- a/overlays/holo-nixpkgs/holochain/versions.nix
+++ b/overlays/holo-nixpkgs/holochain/versions.nix
@@ -1,8 +1,8 @@
 {
   hpos = {
-    rev = "30045ec5269f2b080bc35002ee01f764d2a95b5e";
-    sha256 = "0zbjd6gwf4409q8j7i71562gfr37l4jwymg89an717vqmsaj2hw3";
-    cargoSha256 = "1zxrlabb4q8v1n4alryvhbcydqkp4v2y9cvfnwa9iifz4nyzac03";
+    rev = "24ceb63bdea374d1936b723e1966caf2e55ebfdc";
+    sha256 = "16hsikyasi0zbh7gfrpzlahydx7csnvshz421sx56f0jpwvi2g80";
+    cargoSha256 = "0w29y8w5k5clq74k84ksj5aqxbxhqxh2djhll6vv694djw277rpj";
     bins = {
       holochain = "holochain";
       hc = "hc";

--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -237,16 +237,16 @@ in
       core_happs = [
        {
          app_id = "core-app";
-         bundle_url = "https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/0_1_0_alpha16/core-app.0_1_0_alpha16.happ";
+         bundle_url = "https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/0_1_0_alpha18/core-app.0_1_0_alpha18.happ";
        }
        {
          app_id = "servicelogger";
-         bundle_url = "https://holo-host.github.io/servicelogger-rsm/releases/downloads/v0.1.0-alpha7/servicelogger.0_1_0-alpha7.happ";
+         bundle_url = "https://holo-host.github.io/servicelogger-rsm/releases/downloads/0_1_0_alpha8/servicelogger.0_1_0_alpha8.happ";
        }
       ];
       self_hosted_happs = [
         {
-          bundle_url = "https://github.com/holochain/elemental-chat/releases/download/v0.2.0-alpha11/elemental-chat.0_2_0_alpha11.happ";
+          bundle_url = "https://github.com/holochain/elemental-chat/releases/download/v0.2.0.alpha13/elemental-chat.0_2_0_alpha13.happ";
           ui_url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha34/elemental-chat-for-dna-0_2_0_alpha11-develop.zip";
         }
       ];

--- a/profiles/logical/hpos/sandbox/default.nix
+++ b/profiles/logical/hpos/sandbox/default.nix
@@ -59,15 +59,15 @@ in
         {
           app_id = "core-app"; # not used, just for clarity here
           bundle_path = builtins.fetchurl {
-            url = "https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/0_1_0_alpha16/core-app.0_1_0_alpha16.happ";
-            sha256 = "1rzs844chmnfj11sjlyl20kb35jknidvsc3x6v10wbqw972khbcd"; # To get sha run `nix-prefetch-url URL`
+            url = "https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/0_1_0_alpha18/core-app.0_1_0_alpha18.happ";
+            sha256 = "09sag44jwfhgqb3gvwcnqz2hins3krcq669cizzsb8bjvx99qn8c"; # To get sha run `nix-prefetch-url URL`
           };
         }
         {
           app_id = "servicelogger";  # not used, just for clarity here
           bundle_path = builtins.fetchurl {
-            url = "https://holo-host.github.io/servicelogger-rsm/releases/downloads/v0.1.0-alpha7/servicelogger.0_1_0-alpha7.happ";
-            sha256 = "1h9yjrrk13h965ycww5r6y4drqcxw2g3p7a4f8dfszqkjyx0pwm7"; # To get sha run `nix-prefetch-url URL`
+            url = "https://holo-host.github.io/servicelogger-rsm/releases/downloads/0_1_0_alpha8/servicelogger.0_1_0_alpha8.happ";
+            sha256 = "1i09fnhzxikxh11jxb75vaiyixpxgd8wqzh4lv70jsaf5cg3063s"; # To get sha run `nix-prefetch-url URL`
           };
         }
       ];
@@ -75,8 +75,8 @@ in
         {
           app_id = "elemental-chat";  # not used, just for clarity here
           bundle_path =  builtins.fetchurl {
-            url = "https://github.com/holochain/elemental-chat/releases/download/v0.2.0-alpha10/elemental-chat.0_2_0_alpha10.happ";
-            sha256 = "1zy4masavhh9n7islrfs719cypkrk1y9fgbl0k78kpkjapzb798a";
+            url = "https://github.com/holochain/elemental-chat/releases/download/v0.2.0.alpha13/elemental-chat.0_2_0_alpha13.happ";
+            sha256 = "1y4i5922mjasf2qj0n6srfby1cpkid64a2r8kscfjwzgpr3k11ky";
           };
           ui_path = builtins.fetchurl {
             url = "https://github.com/holochain/elemental-chat-ui/releases/download/v0.0.1-alpha34/elemental-chat-for-dna-0_2_0_alpha11-develop.zip";


### PR DESCRIPTION
Prepare holo-nixpkgs for the next round of testing.
- [x] Bumped holochain
- [x] Update rust 1.48 -> 1.52
- [x] Updated configure-holochain 
- [x] Update holo-auto-installer
- [x] Bump DNAs: EC, SL, HHA
