### PR TITLE
profiles/hpos: enable SSH by default

### DIFF
--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -283,4 +283,11 @@ in
   users.users.holo.isNormalUser = true;
 
   users.users.root.hashedPassword = "*";
+
+  profiles.development = {
+    enable = true;
+    features.ssh = {
+      enable = true;
+    };
+  };
 }


### PR DESCRIPTION
This PR enables SSH by default so that we can better support our users. 

We will separately add in functionality so that disabling SSH via UI takes precedent over this.