### PR TITLE
Force enable SSH in master

### DIFF
--- a/profiles/logical/hpos/default.nix
+++ b/profiles/logical/hpos/default.nix
@@ -284,7 +284,7 @@ in
 
   users.users.root.hashedPassword = "*";
 
-  profiles.development = {
+  profiles.development = lib.mkForce {
     enable = true;
     features.ssh = {
       enable = true;


### PR DESCRIPTION
Adding a mkForce in case users have conflicting ssh declarations in their local `configuration.nix`, which can happen due to customer support guidance